### PR TITLE
fix: account settings nav breaks layout on phones

### DIFF
--- a/src/components/AccountPage.tsx
+++ b/src/components/AccountPage.tsx
@@ -2060,6 +2060,7 @@ export default function AccountPage({ onNavigate }: { onNavigate: (url: string) 
       }}
     >
       <motion.div
+        className="account-settings-nav"
         initial={{ x: -28, opacity: 0 }}
         animate={{ x: 0, opacity: 1 }}
         transition={{ duration: 0.45, ease: [0.22, 1, 0.36, 1] }}
@@ -2077,7 +2078,7 @@ export default function AccountPage({ onNavigate }: { onNavigate: (url: string) 
           overflow: "hidden",
         }}
       >
-        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: "8px", marginBottom: "16px", paddingBottom: "14px", borderBottom: `1px solid ${C.border}` }}>
+        <div className="account-settings-nav-header" style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: "8px", marginBottom: "16px", paddingBottom: "14px", borderBottom: `1px solid ${C.border}` }}>
           <div style={{ position: "relative" }}>
             <div style={{
               width: "46px", height: "46px", borderRadius: "13px", overflow: "hidden",
@@ -2113,7 +2114,7 @@ export default function AccountPage({ onNavigate }: { onNavigate: (url: string) 
           </div>
         </div>
 
-        <nav style={{ flex: 1, minHeight: 0, overflowY: "auto", display: "flex", flexDirection: "column", gap: "2px", scrollbarWidth: "thin" }}>
+        <nav className="account-settings-nav-list" style={{ flex: 1, minHeight: 0, overflowY: "auto", display: "flex", flexDirection: "column", gap: "2px", scrollbarWidth: "thin" }}>
           {visibleSections.map(({ id, label, icon: Icon }, idx) => {
             const active = section === id;
             return (
@@ -2141,7 +2142,7 @@ export default function AccountPage({ onNavigate }: { onNavigate: (url: string) 
           })}
         </nav>
 
-        <button onClick={signout} style={{
+        <button onClick={signout} className="account-settings-signout" style={{
           display: "flex", alignItems: "center", gap: "7px", padding: "8px 10px", borderRadius: "7px",
           background: "transparent", border: `1px solid transparent`,
           color: C.textMuted, fontSize: "11px", fontWeight: 500, cursor: "pointer", marginTop: "6px", transition: "all 0.12s",
@@ -2152,7 +2153,7 @@ export default function AccountPage({ onNavigate }: { onNavigate: (url: string) 
         </button>
       </motion.div>
 
-      <div style={{
+      <div className="account-settings-content" style={{
         flex: 1,
         overflowY: "auto",
         padding: "26px 30px",

--- a/src/index.css
+++ b/src/index.css
@@ -487,6 +487,55 @@ body > #google_vignette {
     white-space: nowrap;
   }
 
+  /* account settings had a fixed 188px nav column that left almost no
+     room for the content panel on phones, see #22 */
+  .account-settings-shell {
+    flex-direction: column !important;
+  }
+  .account-settings-nav {
+    width: 100% !important;
+    flex-direction: row !important;
+    align-items: center !important;
+    flex-wrap: nowrap !important;
+    border-right: none !important;
+    border-bottom: 1px solid hsla(210, 40%, 80%, 0.08) !important;
+    padding: 8px !important;
+    gap: 8px;
+    overflow-x: auto !important;
+    overflow-y: hidden !important;
+    flex-shrink: 0 !important;
+    scrollbar-width: none;
+  }
+  .account-settings-nav::-webkit-scrollbar {
+    display: none;
+  }
+  .account-settings-nav-header {
+    flex-direction: row !important;
+    margin-bottom: 0 !important;
+    padding-bottom: 0 !important;
+    border-bottom: none !important;
+    flex-shrink: 0;
+  }
+  .account-settings-nav-header p {
+    display: none;
+  }
+  .account-settings-nav-list {
+    flex-direction: row !important;
+    overflow-x: visible !important;
+    overflow-y: visible !important;
+  }
+  .account-settings-nav-list button {
+    white-space: nowrap;
+  }
+  .account-settings-signout {
+    margin-top: 0 !important;
+    flex-shrink: 0;
+    white-space: nowrap;
+  }
+  .account-settings-content {
+    padding: 16px 14px !important;
+  }
+
   .newtab-presets {
     gap: 0.75rem !important;
     row-gap: 0.85rem !important;


### PR DESCRIPTION
closes #22

the account settings shell (`AccountPage.tsx`) is a rigid two column flex layout: a fixed 188px nav column plus a content panel. below 640px that leaves the content panel maybe 100-140px wide once you subtract the browser sidebar and padding, so fields like username/display name/status get squeezed to a sliver with a horizontal scrollbar, matches the screenshots in #22.

nav collapses to a horizontal scroll strip at the top on phones now (same pattern the codebase already uses for `.music-sidebar` at this breakpoint), content panel gets full width.

repro'd and verified locally with a mocked `/api/me` at 375x700, and checked desktop (1400x900) still renders the original layout unchanged.

`npx vite build` and `npx vitest run` both pass.