### PR TITLE
fix: clear error when GROQ_API_KEY is unset in ai route

### DIFF
--- a/backend/routes/ai.js
+++ b/backend/routes/ai.js
@@ -166,6 +166,7 @@ function enqueue(task) {
 }
 
 router.post('/', async (req, res) => {
+  if (!process.env.GROQ_API_KEY) return res.status(500).json({ error: 'AI service not configured' });
   const ip = toIPv4(null, req);
   if (checkCircuitBreaker(ip, null)) return res.status(429).json({ error: 'Too many requests' });
 


### PR DESCRIPTION
small follow-up after closing #110.

that PR framed this as a critical 'leaked API key' fix, which wasn't accurate, `GROQ_API_KEY` was already only ever read from `process.env`, never hardcoded. but the one actual line of substance in it was a reasonable guard: right now if the key is unset, the request falls through to the groq fetch and comes back as a confusing 502/GROQ_ERROR instead of a clean, obvious error.

pulling just that in on its own, no vulnerability, just a nicer failure mode.