### PR TITLE
fix: client IP detection trusts client-suppliable header first

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,14 @@
-# **PeteZahGames**
+# PeteZah
 
-A unblocked gaming site for you that self hosts over 400+ games from reliable
-sources.
+A privacy-oriented web browser with HTML5 games, a licensed movie directory, and general web access.
 
-## Our Purpose
+## Purpose
 
-We are mainly a service that provides games completely self hosted but we also
-have a proxy!
+PeteZah is a privacy browser. Games are part of the catalog. The proxy is for lawful, general internet use. We do not condone illegal sites or violating someone else's network policy.
 
-You're mainly supposed to use our site at places that have restrictions.
+Get current domains from the site or Discord when a particular hostname is filtered.
 
-## Our Tech Stack
+## Tech stack
 
 - We use Supabase for our account system
 - We use Titanium Network's ultraviolet proxy and scramjet.
@@ -70,14 +68,14 @@ If you would like to use one of the following buttons to deploy
 > [![Deploy to Koyeb](https://binbashbanana.github.io/deploy-buttons/buttons/remade/koyeb.svg)](https://app.koyeb.com/deploy?type=git&repository=github.com/PeteZah-Games/petezahgames&branch=Main&name=petezahgames)
 > [![Deploy to Render](https://binbashbanana.github.io/deploy-buttons/buttons/remade/render.svg)](https://render.com/deploy?repo=https://github.com/PeteZah-Games/petezahgames)
 
-## Links
+## Continuity links
 
-(Links with "(gg)" are unblocked by GoGuardian, others are untested)
+Some hostnames work in more places than others. Check Discord for current mirrors.
 
 > [!IMPORTANT] You can get more links in our
 > [Discord Server](https://discord.gg/unrestricted)
 
-## Wildcard (replace the \* with anything you want, for GoGuardian using the keyword "math" is recommended. )
+## Wildcard (replace * with any subdomain)
 
 - https://\*.supergisfire.com.cdn.cloudflare.net/
 

--- a/backend/api/copyright.js
+++ b/backend/api/copyright.js
@@ -1,0 +1,101 @@
+import rateLimit from 'express-rate-limit';
+import { randomUUID } from 'crypto';
+import db from '../db.js';
+import { toIPv4 } from '../middleware/security.js';
+import { getClientIP } from '../utils/client-ip.js';
+import { sanitizeGameId } from './game-stats.js';
+import { isOwnerEmail } from '../utils/auth-roles.js';
+
+export const copyrightReportLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 8,
+  keyGenerator: (req) => req.session?.user?.id || toIPv4(null, req),
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (_req, res) => res.status(429).json({ error: 'Too many reports. Try again later.' }),
+});
+
+function requireAdmin(req, res) {
+  if (!req.session?.user) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return null;
+  }
+  const row = db.prepare('SELECT is_admin, email FROM users WHERE id = ?').get(req.session.user.id);
+  if (!row) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return null;
+  }
+  const owner = isOwnerEmail(row.email);
+  if ((row.is_admin || 0) < 1 && !owner) {
+    res.status(403).json({ error: 'Forbidden' });
+    return null;
+  }
+  return req.session.user;
+}
+
+export function ensureCopyrightTables() {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS copyright_reports (
+      id TEXT PRIMARY KEY,
+      target_type TEXT NOT NULL,
+      target_id TEXT,
+      target_url TEXT,
+      title TEXT,
+      contact_email TEXT,
+      work TEXT,
+      statement TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      ip TEXT,
+      status TEXT NOT NULL DEFAULT 'open'
+    );
+    CREATE INDEX IF NOT EXISTS idx_copyright_reports_created ON copyright_reports(created_at DESC);
+  `);
+}
+
+ensureCopyrightTables();
+
+export async function copyrightReportHandler(req, res) {
+  const statement = typeof req.body?.statement === 'string' ? req.body.statement.trim().slice(0, 4000) : '';
+  if (statement.length < 20) {
+    return res.status(400).json({ error: 'Please describe the work and where it appears (at least 20 characters).' });
+  }
+  const contact = typeof req.body?.email === 'string' ? req.body.email.trim().toLowerCase().slice(0, 254) : '';
+  if (contact && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(contact)) {
+    return res.status(400).json({ error: 'Invalid email.' });
+  }
+  const targetType = typeof req.body?.targetType === 'string' ? req.body.targetType.trim().slice(0, 20) : 'game';
+  const targetId = sanitizeGameId(req.body?.targetId) || '';
+  const targetUrl = typeof req.body?.url === 'string' ? req.body.url.trim().slice(0, 800) : '';
+  const title = typeof req.body?.title === 'string' ? req.body.title.trim().slice(0, 160) : '';
+  const work = typeof req.body?.work === 'string' ? req.body.work.trim().slice(0, 400) : '';
+  const id = randomUUID();
+  db.prepare(
+    `INSERT INTO copyright_reports
+      (id, target_type, target_id, target_url, title, contact_email, work, statement, created_at, ip, status)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'open')`
+  ).run(
+    id,
+    targetType,
+    targetId || null,
+    targetUrl || null,
+    title || null,
+    contact || null,
+    work || null,
+    statement,
+    Date.now(),
+    getClientIP(req) || null,
+  );
+  return res.json({ ok: true, id, message: 'Report received. We review complete notices and disable access when required.' });
+}
+
+export function copyrightReportsAdminHandler(req, res) {
+  if (!requireAdmin(req, res)) return;
+  const rows = db
+    .prepare(
+      `SELECT id, target_type as targetType, target_id as targetId, target_url as targetUrl, title,
+              contact_email as email, work, statement, created_at as createdAt, status
+       FROM copyright_reports ORDER BY created_at DESC LIMIT 200`
+    )
+    .all();
+  return res.json({ reports: rows });
+}

--- a/backend/api/signup.js
+++ b/backend/api/signup.js
@@ -70,7 +70,7 @@ export async function signupHandler(req, res) {
 
   if (!acceptedLegal) {
     return res.status(400).json({
-      error: 'You must agree to the Terms of Service, Privacy Policy, and DMCA Policy to create an account.',
+      error: 'You must agree to the Terms of Service, Privacy Policy, and Copyright Policy to create an account.',
     });
   }
 

--- a/backend/legal/accept.js
+++ b/backend/legal/accept.js
@@ -13,7 +13,7 @@ export function legalStatusHandler(req, res) {
 export function legalAcceptHandler(req, res) {
   const accepted = req.body?.accepted === true || req.body?.accepted === 'true' || req.body?.accepted === 1;
   if (!accepted) {
-    return res.status(400).json({ error: 'You must accept the Terms, Privacy Policy, and DMCA Policy to continue.' });
+    return res.status(400).json({ error: 'You must accept the Terms, Privacy Policy, and Copyright Policy to continue.' });
   }
 
   const version = typeof req.body?.version === 'string' ? req.body.version.trim() : '';

--- a/backend/legal/documents.js
+++ b/backend/legal/documents.js
@@ -8,7 +8,7 @@ import {
 
 export const TERMS_TITLE = 'Terms of Service';
 export const PRIVACY_TITLE = 'Privacy Policy';
-export const DMCA_TITLE = 'DMCA / Copyright Policy';
+export const DMCA_TITLE = 'Copyright Policy';
 
 export const TERMS_BODY = `Last Updated / Effective Date: ${LEGAL_EFFECTIVE}
 Document Version: ${LEGAL_VERSION}
@@ -17,31 +17,33 @@ IMPORTANT — PLEASE READ CAREFULLY
 
 These Terms of Service (the "Terms") form a legally binding agreement between you ("you," "your," or "User") and the operators of PeteZah / Arc Glass Browser and related domains, mirrors, embeds, link-distribution tools, games, apps, and services (collectively, the "Service," "we," "us," or "our").
 
-BY ACCESSING OR USING THE SERVICE — INCLUDING COMPLETING ANY VERIFICATION GATE, CREATING AN ACCOUNT, CLICKING "I AGREE," CHECKING AN ACCEPTANCE BOX, OR CONTINUING TO USE THE SERVICE AFTER NOTICE OF THESE TERMS — YOU ACKNOWLEDGE THAT YOU HAVE READ, UNDERSTOOD, AND AGREE TO BE BOUND BY THESE TERMS, OUR PRIVACY POLICY, AND OUR DMCA / COPYRIGHT POLICY. IF YOU DO NOT AGREE, DO NOT USE THE SERVICE.
+BY ACCESSING OR USING THE SERVICE — INCLUDING COMPLETING ANY VERIFICATION GATE, CREATING AN ACCOUNT, CLICKING "I AGREE," CHECKING AN ACCEPTANCE BOX, OR CONTINUING TO USE THE SERVICE AFTER NOTICE OF THESE TERMS — YOU ACKNOWLEDGE THAT YOU HAVE READ, UNDERSTOOD, AND AGREE TO BE BOUND BY THESE TERMS, OUR PRIVACY POLICY, AND OUR COPYRIGHT POLICY. IF YOU DO NOT AGREE, DO NOT USE THE SERVICE.
 
-These Terms are intended to allocate risk clearly. They are not a license to break the law, violate institutional policies, or harm others.
+These Terms allocate risk clearly. They are not a license to break the law, violate institutional policies, or harm others.
 
 
-1. Nature of the Service; Privacy / Safe-Haven Purpose
+1. Nature of the Service; Privacy Purpose
 
-1.1 The Service is offered as a privacy-oriented access and browsing tool, including proxy/relay features, optional account features, educational and entertainment content catalogs (games, apps, and similar embeds), optional link-related utilities, virtual-machine style tools, chat or community features, and advertising-supported free access.
+1.1 The Service is a privacy-oriented browsing and access tool. It includes a full-internet proxy/relay, optional accounts, entertainment catalogs (games and apps), a movie/TV directory that points to licensed streaming services, optional background-music embeds, alternative-URL utilities, experimental virtual-machine tools, community features, and advertising-supported free access.
 
-1.2 We may distribute or publish alternative URLs, mirrors, embeds, or "unblocked" access points so people can reach privacy-oriented tooling when mainstream paths are filtered. THAT CAPABILITY DOES NOT MEAN WE CONDONE, ENCOURAGE, AUTHORIZE, OR ASSUME RESPONSIBILITY FOR VIOLATING SCHOOL, EMPLOYER, LIBRARY, GOVERNMENT, ISP, PARENTAL, OR OTHER NETWORK, DEVICE, OR ACCEPTABLE-USE POLICIES. THE SERVICE IS A TECHNICAL SAFE-HAVEN / PRIVACY TOOL, NOT PERMISSION TO CIRCUMVENT RULES THAT APPLY TO YOU.
+1.2 We may publish alternative hostnames, mirrors, embeds, or continuity links so people can still reach THIS Service when a particular domain of ours is filtered. That is access continuity for our own properties. IT IS NOT PERMISSION TO VIOLATE SCHOOL, EMPLOYER, LIBRARY, GOVERNMENT, ISP, PARENTAL, OR OTHER NETWORK, DEVICE, OR ACCEPTABLE-USE POLICIES. Using the Service on a managed device or network remains solely your responsibility.
 
-1.3 You alone decide whether your use is lawful and permitted under every policy that binds you. If your school, workplace, parent/guardian, or network forbids this Service or similar tools, you must not use it on those systems or under those rules.
+1.3 You alone decide whether your use is lawful and permitted under every policy that binds you. If your school, workplace, parent/guardian, or network forbids this Service or similar tools, you must not use it on those systems.
 
-1.4 We do not guarantee anonymity, undetectability, unblockability, or that any filter, firewall, MDM, or monitoring system will fail to detect your use.
+1.4 We do not guarantee anonymity, undetectability, or that any filter, firewall, MDM, or monitoring system will fail to notice your use. We do not market the Service as a way to hide misconduct.
 
 
 2. Eligibility; Accounts; Age
 
-2.1 You must be legally able to form a binding contract where you live. If you are under the age of majority, you may use the Service only with verifiable parental/guardian consent where required, and only if permitted by applicable law.
+2.1 You must be at least 13 years old to use the Service. If you are 13 or older but under the age of majority where you live, you may use the Service only with a parent or guardian's permission, and only if permitted by applicable law. A parent or guardian who permits such use is responsible for that use.
 
-2.2 The Service is not directed to children under 13 (or under 16 where a higher digital-consent age applies). Do not create an account or submit personal data if you are below the applicable age.
+2.2 The Service is a general-audience product. It is not directed to children under 13, is not intended as a children's app, and we do not knowingly collect personal information from children under 13 (or under 16 where a higher digital-consent age applies). Do not create an account or submit personal data if you are below that age.
 
-2.3 You are responsible for the accuracy of account information, safeguarding credentials and session cookies, and all activity under your account or device. Notify us promptly of unauthorized access.
+2.3 Advertising, third-party websites you open, and some catalog items may include material that is inappropriate for younger users. We are not an 18+ service, but we do not claim the Service is suitable for every age. Parents and guardians should supervise minors.
 
-2.4 We may refuse, suspend, rate-limit, shadow-limit, or terminate access or accounts at any time, with or without notice, for any reason permitted by law, including suspected abuse, fraud, ToS breach, legal risk, or operational need.
+2.4 You are responsible for the accuracy of account information, safeguarding credentials and session cookies, and all activity under your account or device. Notify us promptly of unauthorized access.
+
+2.5 We may refuse, suspend, rate-limit, or terminate access or accounts at any time, with or without notice, for reasons permitted by law, including suspected abuse, fraud, legal risk, or operational need.
 
 
 3. User Responsibilities; Acceptable Use
@@ -59,42 +61,53 @@ You agree you will NOT, and will not assist others to:
 (i) resell, sublicense, or commercially exploit the Service without written permission;
 (j) misrepresent affiliation with us or use our branding in a misleading way;
 (k) use the Service to commit academic dishonesty, exam cheating, or unauthorized testing interference where prohibited;
-(l) use the Service in any way that creates legal, security, or reputational risk for us or other users.
+(l) use the Service to visit, host, or traffic in illegal websites or material, or to pirate copyrighted works.
 
 We may investigate and cooperate with schools, employers, ISPs, platforms, payment providers, and law enforcement as required or permitted by law.
 
 
-4. Network Policies; "Unblocked" Access; Get Links and Mirrors
+4. Access Continuity; Get Links and Mirrors
 
-4.1 Features that share alternative domains, embeds, QR codes, invite links, or similar ("Link Features") exist so users can find the Service when ordinary routes are blocked. Link Features are provided AS IS for privacy/access continuity.
+4.1 Features that share alternative domains, embeds, QR codes, or similar ("Link Features") exist so users can keep reaching OUR Service if a listed network filter blocks one of our hostnames. You may choose a filter category so we can return a mirror that we expect to work in that environment. Link Features are provided AS IS for access continuity. They are not advice to violate anyone's acceptable-use policy.
 
-4.2 We do NOT warrant that any link will remain online, unblocked, safe, or free of third-party interference. Links may be taken down, poisoned, parked, or replaced without notice.
+4.2 We do NOT warrant that any link will remain online, reachable, safe, or free of third-party interference. Links may be taken down, parked, or replaced without notice.
 
-4.3 You are solely responsible for how you obtain, share, or use links. Sharing links in violation of institutional rules, copyright, or law is your responsibility. We are not your attorney, compliance officer, or school administrator.
+4.3 You are solely responsible for how you obtain, share, or use links. Sharing or using links in violation of institutional rules or law is your responsibility. We are not your attorney, compliance officer, or school administrator.
 
-4.4 If you use the Service on a managed device (school Chromebook, corporate laptop, etc.), monitoring software may still log activity. You accept that risk entirely.
+4.4 If you use the Service on a managed device, monitoring software may still log activity. You accept that risk entirely.
 
 
 5. Proxy, Relay, and Third-Party Sites
 
-5.1 When you browse through our proxy/relay, you are requesting third-party content. We are not the publisher of that content. Third-party sites have their own terms and privacy practices.
+5.1 The proxy/relay is a general-purpose browsing tunnel. You may request the public internet through it. We are not the publisher of third-party sites you open. Those sites have their own terms and privacy practices.
 
-5.2 We do not endorse third-party sites. Content may be inaccurate, offensive, malicious, or illegal. You interact with third parties at your own risk.
+5.2 We do not endorse third-party sites and we do not condone illegal websites. Content may be inaccurate, offensive, malicious, or unlawful. You interact with third parties at your own risk and must follow the law and the destination site's rules.
 
-5.3 Proxying does not grant you rights in third-party content. Do not use the Service to pirate, traffic stolen credentials, or commit fraud.
+5.3 Proxying does not grant you rights in third-party content. Do not use the Service to pirate, steal credentials, commit fraud, or access material you are not allowed to access.
 
-5.4 We may block destinations, strip headers, rewrite URLs, terminate connections, or refuse proxying for safety, legal, or abuse reasons.
+5.4 We may block destinations, strip headers, rewrite URLs, terminate connections, or refuse proxying for safety, legal, or abuse reasons. Blocking is discretionary and is not a guarantee that remaining destinations are lawful.
 
 
-6. Games, Apps, Media, Embeds, and Catalogs
+6. Games, Apps, Movies, Music, and Catalogs
 
-6.1 Games, apps, emulators, media players, flash/HTML5 ports, and similar catalog items may be hosted by us, embedded from third parties, or loaded via user action. Copyright and trademarks belong to their respective owners unless expressly stated otherwise.
+6.1 The games catalog is an operator-maintained index assembled from third-party and public sources (including public lists, mirrors, embeds, and user suggestions). Appearance on the list is not ownership, not a license grant to you, and not a representation that we independently verified authorization for every playable copy in every jurisdiction.
 
-6.2 Catalog availability is not a representation that we own the underlying works, that distribution is authorized in every jurisdiction, or that a title will remain available.
+6.2 How a title is delivered matters, and we do not treat them as the same thing:
+(a) metadata or a listing alone is not a copy of the work;
+(b) some items are files or assets we store and serve (hosted copies);
+(c) some items load from a third-party URL through an embed or the proxy/relay;
+(d) some items are links or forms that send you to another site.
+Legal risk, if any, follows the playable copy and the method of delivery — not the fact that a title appears in a combined list.
 
-6.3 If you believe catalog or hosted material infringes your rights, use our DMCA / Copyright Policy. Do not send abusive or knowingly false notices.
+6.3 We do not claim that catalog games are "user-uploaded" or "user-submitted works stored at the direction of users" merely because suggestions, public lists, or request forms helped us find them. Staff and operators decide what is listed. Individual users may add private custom shortcuts in their own browser settings; those are that user's links, not our worldwide catalog, unless an operator later adds them globally.
 
-6.4 Virtual machine, remote browser, or sandboxed tools are experimental. They may fail, lose data, expose identifiers, or be withdrawn. Do not store secrets or illegal material in them.
+6.4 Copyrights, trademarks, and related rights in third-party games remain with their owners unless we expressly state otherwise. If you are a rights holder, use the Copyright Policy. A listing is not a warranty that the item will remain available. We disable or remove access after a complete, good-faith notice identifying material we host or control, keep a record of the complaint, and take reasonable steps so the same item is not casually restored.
+
+6.5 Movies and TV in the Service are a directory only. We do not host movie or TV files and we do not embed unauthorized streams. Buttons open official licensed services (for example Netflix, Prime Video, Hulu, or others listed for your region) so you can sign in and watch under THAT provider's terms.
+
+6.6 Optional music playback is a convenience overlay — official YouTube and SoundCloud embeds so you can listen while using other parts of the Service. It is not a dedicated music-download service, and we do not host audio files.
+
+6.7 Virtual machine, remote browser, or sandboxed tools are experimental. They may fail, lose data, expose identifiers, or be withdrawn. Do not store secrets or illegal material in them.
 
 
 7. Advertising; Ad Networks; Malicious or Misleading Ads
@@ -131,7 +144,7 @@ If you post comments, feedback, profiles, avatars, or other content ("User Conte
 
 11. Disclaimers
 
-THE SERVICE IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, NON-INFRINGEMENT, QUIET ENJOYMENT, ACCURACY, OR UNINTERRUPTED / ERROR-FREE / SECURE OPERATION. WE DO NOT WARRANT THAT THE SERVICE WILL REMAIN UNBLOCKED, PRIVATE, OR AVAILABLE IN YOUR LOCATION.
+THE SERVICE IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, NON-INFRINGEMENT, QUIET ENJOYMENT, ACCURACY, OR UNINTERRUPTED / ERROR-FREE / SECURE OPERATION. WE DO NOT WARRANT THAT THE SERVICE WILL REMAIN REACHABLE, PRIVATE, OR AVAILABLE IN YOUR LOCATION.
 
 
 12. Limitation of Liability
@@ -155,7 +168,7 @@ We may suspend or terminate the Service or your access immediately. Upon termina
 
 15. Changes
 
-We may update these Terms by posting a new version and updating the effective date / version identifier. Material changes may also be signaled via the Service. Continued use after the effective date constitutes acceptance. If you disagree, stop using the Service and delete your account.
+We may update these Terms by posting a new version and updating the effective date / version identifier. Material changes may also be signaled via the Service (including a required acceptance prompt). Continued use after the effective date constitutes acceptance. If you disagree, stop using the Service and delete your account.
 
 
 16. Governing Law; Disputes; Informal Resolution
@@ -165,21 +178,21 @@ To the extent permitted by law, these Terms are governed by the laws applicable 
 
 17. Miscellaneous
 
-If any provision is unenforceable, the remainder stays in effect. Our failure to enforce a provision is not a waiver. These Terms, the Privacy Policy, and the DMCA / Copyright Policy are the entire agreement regarding the Service and supersede prior understandings on that subject. You may not assign these Terms without our consent; we may assign them in connection with a reorganization or change of operators. Headings are for convenience only. "Including" means "including without limitation."
+If any provision is unenforceable, the remainder stays in effect. Our failure to enforce a provision is not a waiver. These Terms, the Privacy Policy, and the Copyright Policy are the entire agreement regarding the Service and supersede prior understandings on that subject. You may not assign these Terms without our consent; we may assign them in connection with a reorganization or change of operators. Headings are for convenience only. "Including" means "including without limitation."
 
 
 18. Contact
 
 Email: ${LEGAL_CONTACT_EMAIL}
-DMCA / copyright: ${LEGAL_DMCA_EMAIL}
+Copyright: ${LEGAL_DMCA_EMAIL}
 Community: ${LEGAL_DISCORD}
 
-By checking the agreement box on verification or signup, or by continuing to use the Service, you confirm acceptance of these Terms, the Privacy Policy, and the DMCA / Copyright Policy (version ${LEGAL_VERSION}).`;
+By checking the agreement box on verification or signup, accepting the in-app prompt, or continuing to use the Service, you confirm acceptance of these Terms, the Privacy Policy, and the Copyright Policy (version ${LEGAL_VERSION}).`;
 
 export const PRIVACY_BODY = `Last Updated / Effective Date: ${LEGAL_EFFECTIVE}
 Document Version: ${LEGAL_VERSION}
 
-This Privacy Policy explains what information PeteZah / Arc Glass Browser and related services (the "Service," "we," "us") collect, how we use it, and the choices you have. It should be read with our Terms of Service and DMCA / Copyright Policy.
+This Privacy Policy explains what information PeteZah / Arc Glass Browser and related services (the "Service," "we," "us") collect, how we use it, and the choices you have. It should be read with our Terms of Service and Copyright Policy.
 
 
 1. Scope
@@ -193,7 +206,7 @@ This Policy covers data processed when you visit our sites, pass verification, c
 
 2.2 Security, session, and anti-abuse data: IP addresses (and derived geolocation/ASN where available); user-agent and basic device/browser signals; timestamps of access, sign-in, sign-up, and sensitive actions; session identifiers and cookies (including authentication sessions and verification/legal-acceptance cookies); CAPTCHA / proof-of-work challenge metadata; rate-limit counters; ban and reputation signals; rough connection or presence signals used for live-site / capacity features; referral or landing path where relevant to abuse review.
 
-2.3 Service usage (operational): feature usage necessary to operate the product (e.g. settings sync payloads you choose to save; link-claim events and cooldowns; feedback/comments you submit; admin audit actions). We aim NOT to build a commercial advertising profile of your private browsing destinations, but technical logs needed for reliability and abuse prevention may incidentally include request metadata.
+2.3 Service usage (operational): feature usage necessary to operate the product (e.g. settings sync payloads you choose to save; link-claim events and cooldowns; feedback/comments you submit; copyright reports you submit; admin audit actions). We may keep operational catalog records such as game identifiers, delivery URLs, source or provider notes where we have them, exclusion/takedown status, and related timestamps. We aim NOT to build a commercial advertising profile of your private browsing destinations, but technical logs needed for reliability and abuse prevention may incidentally include request metadata.
 
 2.4 Proxy / technical transmission: while proxying, systems necessarily process URLs, headers, and content bytes in transit to fulfill your request. We do not sell your browsing history. Retention of detailed proxy destination logs, if any, is limited to what we reasonably need for security, debugging, capacity, and legal compliance, then discarded or aggregated.
 
@@ -206,7 +219,7 @@ This Policy covers data processed when you visit our sites, pass verification, c
 
 3. How We Use Information
 
-We use information to: provide and maintain the Service; authenticate users; verify email where required for certain features; enforce Terms; detect bots, fraud, credential stuffing, DDoS, scraping, and other abuse; apply bans and cooldowns; improve performance and UX; communicate service notices; comply with law and valid legal process; and protect users, operators, and the public.
+We use information to: provide and maintain the Service; authenticate users; verify email where required for certain features; enforce Terms; detect bots, fraud, credential stuffing, DDoS, scraping, and other abuse; apply bans and cooldowns; respond to copyright and legal notices; improve performance and UX; communicate service notices; comply with law and valid legal process; and protect users, operators, and the public.
 
 
 4. Anti-Abuse Philosophy (What "Generous but Firm" Means)
@@ -221,7 +234,7 @@ Where GDPR/UK GDPR or similar frameworks apply, we rely on one or more of: perfo
 
 6. Sharing and Disclosure
 
-We do not sell your personal information as "sale" is commonly understood for raw email lists. We may share data with: infrastructure and email providers acting on our instructions; Ad Partners and analytics vendors as needed to display/measure ads and traffic; professional advisors; and authorities or complainants when required by law or necessary to protect rights, safety, or the Service (including responding to valid DMCA or security reports). Business transfers (e.g. change of operators) may include user data as an asset under continued confidentiality commitments where feasible.
+We do not sell your personal information as "sale" is commonly understood for raw email lists. We may share data with: infrastructure and email providers acting on our instructions; Ad Partners and analytics vendors as needed to display/measure ads and traffic; professional advisors; and authorities or complainants when required by law or necessary to protect rights, safety, or the Service (including responding to valid copyright or security reports). Business transfers (e.g. change of operators) may include user data as an asset under continued confidentiality commitments where feasible.
 
 
 7. Cookies and Similar Technologies
@@ -231,7 +244,7 @@ We use essential cookies/tokens for sessions, security gates, and recording that
 
 8. Retention
 
-We retain account data while your account remains active and for a reasonable period afterward for security, dispute, and legal purposes. Security logs are kept for rolling windows appropriate to abuse investigation. You may request account deletion subject to residual backup/log copies and legal holds.
+We retain account data while your account remains active and for a reasonable period afterward for security, dispute, and legal purposes. Security logs are kept for rolling windows appropriate to abuse investigation. Copyright reports, catalog exclusions, and related provenance or takedown notes are kept as needed to handle notices, prevent casual re-listing of disabled items, and maintain repeat-infringer records. You may request account deletion subject to residual backup/log copies and legal holds.
 
 
 9. Security
@@ -253,7 +266,7 @@ California / similar U.S. state laws: we do not knowingly "sell" or "share" pers
 
 12. Children
 
-We do not knowingly collect personal information from children under 13 (or the applicable higher age). If you believe we have, contact us and we will take appropriate steps to delete it.
+The Service is not directed at children under 13. We do not knowingly collect personal information from children under 13 (or the applicable higher age). If you are a parent or guardian and believe a child under 13 provided personal information, contact us and we will take appropriate steps to delete it. Users 13–17 should have a parent or guardian review these policies. Advertising and third-party sites may not be appropriate for younger users.
 
 
 13. Do Not Track
@@ -268,7 +281,7 @@ We are not responsible for privacy practices of third-party sites, apps, ad land
 
 15. Changes
 
-We may update this Policy by posting a new version and version identifier. Continued use after the effective date means you accept the updated Policy. Re-acceptance may be required at the verification gate when the legal version changes.
+We may update this Policy by posting a new version and version identifier. Continued use after the effective date means you accept the updated Policy. Re-acceptance may be required via an in-app prompt or verification gate when the legal version changes.
 
 
 16. Contact
@@ -279,30 +292,53 @@ Community: ${LEGAL_DISCORD}`;
 export const DMCA_BODY = `Last Updated / Effective Date: ${LEGAL_EFFECTIVE}
 Document Version: ${LEGAL_VERSION}
 
-This DMCA / Copyright Policy describes how PeteZah / Arc Glass Browser (the "Service," "we," "us") responds to claims of copyright infringement and related intellectual-property complaints involving material on or linked from our properties, including games and apps catalogs, embeds, user-submitted content, and hosted files.
+This Copyright Policy describes how PeteZah / Arc Glass Browser (the "Service," "we," "us") handles claims of copyright infringement and related intellectual-property complaints involving material on or linked from our properties.
 
 
 1. Respect for Copyright
 
-We respect intellectual property rights. Games, applications, artwork, audio, video, brands, and other works accessible through the Service generally belong to their respective owners. Unless we expressly state otherwise, we do not claim ownership of third-party works. Catalog listings and embeds are provided as a convenience and technical conduit; availability is not a warranty of license in every jurisdiction.
+We respect intellectual property rights. Games, applications, artwork, audio, video, brands, and other works accessible through the Service generally belong to their respective owners. Unless we expressly state otherwise, we do not claim ownership of third-party works.
+
+Availability of a catalog item is not a claim that the work is licensed to us, public domain, or fair use. We do not independently verify a license for every playable copy. Movie and TV buttons open licensed services; we do not host those files.
 
 
-2. Role as Service Provider; Safe Harbor Intent
+2. How the Games Catalog Is Built (Provenance)
 
-Where applicable, we intend to operate consistent with the notice-and-takedown framework of the U.S. Digital Millennium Copyright Act, 17 U.S.C. § 512, and analogous laws. To the extent we qualify as a service provider that stores material at users' direction, caches, or transmits/routes material, we will act expeditiously to remove or disable access to material that is the subject of a valid infringement notice.
+The entertainment catalog is assembled by operators from third-party and public sources: public game lists, mirrors, embeds, partner or community catalogs, and suggestions (including a request form). Combining lists is not a license to redistribute the underlying works.
+
+We distinguish:
+(a) listings and metadata (title, artwork URL, categories);
+(b) hosted copies (files or assets we store and serve);
+(c) proxied or embedded third-party playable URLs;
+(d) outbound links to another site.
+
+A complete notice should identify the catalog title or ID and, where possible, the play URL. Primary risk, if any, attaches to (b) and (c), not to the existence of a combined list.
+
+This catalog is operator-maintained. It is not a user-upload locker, and we do not describe it as material stored solely at the direction of users merely because the public or a request form suggested titles.
 
 
-3. What This Policy Covers
+3. Notice-and-Takedown; Records We Keep
 
-This Policy covers allegedly infringing material that we host or control (for example: uploaded assets, mirrored game files we store, user avatars, comments). It may also guide how we handle clear notices about embedded third-party players or deep links when removal on our side is technically feasible. We cannot control the entire public internet reachable through a proxy; for purely third-party sites you browse, send notices to that site's operator as well.
+We operate a notice-and-takedown process. When we receive a complete, good-faith copyright notice that identifies material we host or control, we review it and disable or remove access (for example by excluding a game from the catalog).
+
+Where reasonably available, we record or retain: title or game ID; delivery URL; source or provider notes; who added or requested it if known; permission/license status if we have it (often "unverified"); when it was listed; takedown or exclusion status; and the complaint itself. The purpose is to identify the copy, disable it, preserve the notice, reduce accidental re-addition, and contact an upstream source when that is appropriate. Incomplete records do not mean we will ignore a locatable notice.
+
+This policy describes our operations. It does not claim that every kind of content on the Service automatically qualifies for a particular statutory safe harbor. We still honor valid notices.
+
+We cannot control the entire public internet reachable through the proxy. For sites we do not host, send notices to that site's operator as well.
 
 
-4. Filing a DMCA Takedown Notice
+4. What We Can Disable
 
-To be valid under 17 U.S.C. § 512(c)(3), a notice must include substantially the following:
+This Policy covers material we host or control (for example: game files or embeds in our catalog, user avatars, comments, mirrored assets we store). If our UI specifically embeds or hosts a copy, include that URL or catalog title in your notice. For purely third-party sites you browse through the proxy, we are a conduit, not the host.
 
-(1) Identification of the copyrighted work claimed to have been infringed (or a representative list if multiple works on a single site are covered by one notice);
-(2) Identification of the material that is claimed to be infringing, and information reasonably sufficient to permit us to locate it (direct URLs, screenshot paths, catalog titles, file names, and timestamps help enormously);
+
+5. Filing a Copyright Notice
+
+Please include substantially the following (modeled on 17 U.S.C. § 512(c)(3) so we can act quickly):
+
+(1) Identification of the copyrighted work claimed to have been infringed (or a representative list if multiple works are covered by one notice);
+(2) Identification of the material that is claimed to be infringing, and information reasonably sufficient to permit us to locate it (direct URLs, catalog titles, game IDs, file names, and timestamps help);
 (3) Your mailing address, telephone number, and email address;
 (4) A statement that you have a good-faith belief that use of the material in the manner complained of is not authorized by the copyright owner, its agent, or the law;
 (5) A statement that the information in the notice is accurate, and under penalty of perjury, that you are authorized to act on behalf of the owner of an exclusive right that is allegedly infringed;
@@ -311,54 +347,67 @@ To be valid under 17 U.S.C. § 512(c)(3), a notice must include substantially th
 Send notices to:
 Email: ${LEGAL_DMCA_EMAIL}
 CC (optional): ${LEGAL_CONTACT_EMAIL}
-Subject line: DMCA Takedown Notice
+Subject line: Copyright Takedown Notice
 
-We aim to review complete notices within approximately 48–72 hours of receipt, excluding weekends/holidays, but timing is not guaranteed.
-
-
-5. Counter-Notification
-
-If you believe material was removed or disabled by mistake or misidentification, you may send a counter-notification including: your signature; identification of the removed material and where it appeared before removal; a statement under penalty of perjury that you have a good-faith belief the material was removed or disabled by mistake or misidentification; your name, address, and telephone number; and a statement that you consent to the jurisdiction of the Federal District Court for your address (or other competent court as required by law), and that you will accept service of process from the complainant. See 17 U.S.C. § 512(g).
+You may also use the in-product report control on a game, or POST a report through our published report channel. Email with the statements above is the complete method. We aim to review complete notices within approximately 48–72 hours of receipt, excluding weekends/holidays, but timing is not guaranteed. We do not automatically disable items from incomplete or abusive reports.
 
 
-6. Repeat Infringer Policy
+6. What We Do After a Valid Notice
 
-In appropriate circumstances, we terminate accounts and access of users who are repeat infringers. We may also remove catalog items, mirrors, or embeds proactively when we become aware of clear infringement.
+For material we host or control, we aim to:
+(1) identify the listing, file path, or play URL;
+(2) disable access (catalog exclusion and/or removal of hosted or embedded delivery);
+(3) preserve the complaint and related identifiers;
+(4) note the source or provider if we have one, and contact that party when useful;
+(5) keep the item from being casually re-listed;
+(6) consider a counter-notification only if one is actually submitted and legally appropriate.
+
+Disablement is not an admission of liability or of infringement.
 
 
-7. Misrepresentation (Section 512(f))
+7. Counter-Notification
+
+If you believe material was removed or disabled by mistake or misidentification, you may send a counter-notification including: your signature; identification of the removed material and where it appeared before removal; a statement under penalty of perjury that you have a good-faith belief the material was removed or disabled by mistake or misidentification; your name, address, and telephone number; and a statement that you consent to the jurisdiction of the Federal District Court for your address (or other competent court as required by law), and that you will accept service of process from the complainant. See 17 U.S.C. § 512(g) where applicable.
+
+
+8. Repeat Infringer Policy
+
+In appropriate circumstances, we terminate accounts and access of users who are repeat infringers. We may also remove catalog items, mirrors, or embeds when we become aware of a valid claim.
+
+
+9. Misrepresentation
 
 Knowingly materially misrepresenting that material is infringing — or was removed by mistake — may expose the notifier to liability for damages, including costs and attorneys' fees. Do not send bad-faith notices.
 
 
-8. Trademarks and Other Rights
+10. Trademarks and Other Rights
 
-For trademark, right-of-publicity, or similar complaints that are not pure DMCA copyright claims, email ${LEGAL_DMCA_EMAIL} with "IP Complaint" in the subject, a description of your rights, and the precise URLs. We evaluate these in good faith but may require court orders for contested disputes.
-
-
-9. Games, Apps, and Fan Content
-
-Many titles in educational/entertainment catalogs are third-party works. If you are a rights holder for a game, app, ROM, soundtrack, or asset appearing on our Service, a complete DMCA notice is the correct channel. We may remove, geo-restrict, or replace items without admitting liability.
+For trademark, right-of-publicity, or similar complaints that are not copyright claims, email ${LEGAL_DMCA_EMAIL} with "IP Complaint" in the subject, a description of your rights, and the precise URLs. We evaluate these in good faith but may require court orders for contested disputes.
 
 
-10. Proxy Browsing Disclaimer
+11. Games and Fan Content
 
-Browsing arbitrary third-party websites through a proxy does not make us the host of that website's content. Notices solely about destinations we do not store should be directed to the destination operator. If our UI specifically embeds or hosts a copy, include that URL in your notice.
+Many titles in the entertainment catalog are third-party works found via public lists or suggestions. If you are a rights holder, a complete notice is the correct channel. We may disable, geo-restrict, or replace items without admitting liability. Restoration after a valid notice requires a genuine basis (for example a counter-notice, a license, or clear misidentification) — not a new copy from the same unverified dump.
 
 
-11. Fair Use and Other Defenses
+12. Proxy Browsing Disclaimer
+
+Browsing arbitrary third-party websites through a proxy does not make us the host of that website's content. Notices solely about destinations we do not store should be directed to the destination operator. If we specifically embed or reverse-proxy a playable game URL in our catalog, include that catalog entry in the notice so we can disable the listing.
+
+
+13. Fair Use and Other Defenses
 
 Before filing, consider whether the use may be fair use, licensed, public domain, or otherwise authorized. When unsure, consult counsel. We are not your lawyer.
 
 
-12. Advertising Creatives
+14. Advertising Creatives
 
 Ads are frequently served by Ad Partners. Copyright complaints about an ad creative should identify the creative and, where possible, be sent both to us and to the responsible ad network. We will cooperate within reason but do not control every creative in partner inventories.
 
 
-13. Contact
+15. Contact
 
-DMCA agent email: ${LEGAL_DMCA_EMAIL}
+Copyright email: ${LEGAL_DMCA_EMAIL}
 General: ${LEGAL_CONTACT_EMAIL}
 Community: ${LEGAL_DISCORD}`;
 

--- a/backend/legal/pages.js
+++ b/backend/legal/pages.js
@@ -257,7 +257,7 @@ export function renderLegalHtml(kind) {
     <nav class="nav-links">
       <a class="nav-link${kind === 'terms' ? ' active' : ''}" href="/terms">Terms</a>
       <a class="nav-link${kind === 'privacy' ? ' active' : ''}" href="/privacy-policy">Privacy</a>
-      <a class="nav-link${kind === 'dmca' ? ' active' : ''}" href="/dmca">DMCA</a>
+      <a class="nav-link${kind === 'dmca' ? ' active' : ''}" href="/dmca">Copyright</a>
     </nav>
   </header>
   <main class="stage">

--- a/backend/legal/version.js
+++ b/backend/legal/version.js
@@ -1,5 +1,5 @@
-export const LEGAL_VERSION = '2026-07-24';
-export const LEGAL_EFFECTIVE = 'July 24, 2026';
+export const LEGAL_VERSION = '2026-08-17.2';
+export const LEGAL_EFFECTIVE = 'August 17, 2026';
 export const LEGAL_CONTACT_EMAIL = 'contact@petezahgames.com';
 export const LEGAL_DMCA_EMAIL = 'petezahgames@gmail.com';
 export const LEGAL_DISCORD = 'https://discord.petezahgames.com';

--- a/backend/middleware/cap-gate.js
+++ b/backend/middleware/cap-gate.js
@@ -49,7 +49,7 @@ const OPEN_EXACT = new Set([
   '/4f66ddd48bf4ee436b4ca095a86f40ff.html',
 ]);
 
-const OPEN_PREFIX = ['/cap/', '/api/verify-email', '/api/legal', '/vendor/', '/fonts/', '/storage/ag/'];
+const OPEN_PREFIX = ['/cap/', '/api/verify-email', '/api/legal', '/api/copyright', '/vendor/', '/fonts/', '/storage/ag/'];
 
 function isOpenPath(p) {
   if (OPEN_EXACT.has(p)) return true;
@@ -88,6 +88,10 @@ export function createCapGateMiddleware() {
     }
 
     if (p.startsWith('/assets/') || p.endsWith('.js') || p.endsWith('.css') || p.endsWith('.map') || p.endsWith('.woff2') || p.endsWith('.woff') || p.endsWith('.ttf')) {
+      return next();
+    }
+
+    if (hasValidGate(req) && wantsHtml(req)) {
       return next();
     }
 

--- a/backend/middleware/security.js
+++ b/backend/middleware/security.js
@@ -248,7 +248,7 @@ export function adjustPowDifficulty(shield) {
 
 const BOT_PATTERNS = [/googlebot/i, /bingbot/i, /slurp/i, /duckduckbot/i, /baiduspider/i, /yandexbot/i, /facebookexternalhit/i, /facebot/i, /meta-externalagent/i, /meta-externalfetcher/i, /twitterbot/i, /discordbot/i, /telegrambot/i, /whatsapp/i, /linkedinbot/i, /slackbot/i, /archive\.org_bot/i, /ia_archiver/i, /semrushbot/i, /ahrefsbot/i, /mj12bot/i, /dotbot/i];
 
-const OPEN_PATHS = new Set(['/api/signin', '/api/signup', '/api/bot-challenge', '/api/bot-verify', '/api/verify-email', '/api/verify-email/resend', '/api/legal/accept', '/api/legal/status', '/api/me', '/api/signout', '/api/comments', '/api/likes', '/api/changelog', '/api/presence', '/api/announcements/active', '/api/games/play', '/api/games/plays', '/api/games/catalog', '/api/websocket/normal', '/api/websocket/normal/', '/api/websocket/tor', '/api/websocket/tor/']);
+const OPEN_PATHS = new Set(['/api/signin', '/api/signup', '/api/bot-challenge', '/api/bot-verify', '/api/verify-email', '/api/verify-email/resend', '/api/legal/accept', '/api/legal/status', '/api/copyright/report', '/api/me', '/api/signout', '/api/comments', '/api/likes', '/api/changelog', '/api/presence', '/api/announcements/active', '/api/games/play', '/api/games/plays', '/api/games/catalog', '/api/websocket/normal', '/api/websocket/normal/', '/api/websocket/tor', '/api/websocket/tor/']);
 
 function needsToken(reqPath) {
   if (OPEN_PATHS.has(reqPath)) return false;

--- a/backend/middleware/security.js
+++ b/backend/middleware/security.js
@@ -36,8 +36,12 @@ export function toIPv4(ip, req = null) {
     const xff = req.headers['x-forwarded-for'];
     const cf = req.headers['cf-connecting-ip'];
     const real = req.headers['x-real-ip'];
-    if (xff) ip = xff.split(',')[0].trim();
-    else if (cf) ip = cf;
+    // cf-connecting-ip is set by cloudflare's edge and can't be spoofed by the
+    // client, x-forwarded-for can, a client can just send their own value and
+    // we'd trust it. check cf first so rate limits/bans/reputation can't be
+    // bypassed by forging the header.
+    if (cf) ip = cf;
+    else if (xff) ip = xff.split(',')[0].trim();
     else if (real) ip = real;
     else if (req.socket?.remoteAddress) ip = req.socket.remoteAddress;
   }

--- a/backend/routes/ai.js
+++ b/backend/routes/ai.js
@@ -166,6 +166,7 @@ function enqueue(task) {
 }
 
 router.post('/', async (req, res) => {
+  if (!process.env.GROQ_API_KEY) return res.status(500).json({ error: 'AI service not configured' });
   const ip = toIPv4(null, req);
   if (checkCircuitBreaker(ip, null)) return res.status(429).json({ error: 'Too many requests' });
 

--- a/backend/routes/movies.js
+++ b/backend/routes/movies.js
@@ -7,11 +7,45 @@ const TMDB_BASE = 'https://api.themoviedb.org/3';
 
 const cache = new Map();
 const CACHE_TTL = 1000 * 60 * 12;
+const WATCH_TTL = 1000 * 60 * 60 * 18;
 
-function cacheGet(key) {
+const PROVIDER_HOME = {
+  8: 'https://www.netflix.com',
+  9: 'https://www.primevideo.com',
+  15: 'https://www.hulu.com',
+  337: 'https://www.disneyplus.com',
+  1899: 'https://www.max.com',
+  384: 'https://www.max.com',
+  350: 'https://tv.apple.com',
+  2: 'https://tv.apple.com',
+  386: 'https://www.peacocktv.com',
+  387: 'https://www.peacocktv.com',
+  531: 'https://www.paramountplus.com',
+  43: 'https://www.starz.com',
+  37: 'https://www.paramountplus.com',
+  283: 'https://www.crunchyroll.com',
+  73: 'https://tubitv.com',
+  300: 'https://pluto.tv',
+  11: 'https://mubi.com',
+  34: 'https://mubi.com',
+  207: 'https://www.shudder.com',
+  526: 'https://www.amcplus.com',
+  257: 'https://www.fubo.tv',
+  188: 'https://www.youtube.com',
+  192: 'https://www.youtube.com',
+  3: 'https://play.google.com/store/movies',
+  10: 'https://www.amazon.com/gp/video',
+  7: 'https://www.vudu.com',
+  68: 'https://www.microsoft.com/store/movies-and-tv',
+  1796: 'https://www.netflix.com',
+  1825: 'https://www.primevideo.com',
+  175: 'https://www.netflix.com',
+};
+
+function cacheGet(key, ttl = CACHE_TTL) {
   const hit = cache.get(key);
   if (!hit) return null;
-  if (Date.now() - hit.at > CACHE_TTL) {
+  if (Date.now() - hit.at > ttl) {
     cache.delete(key);
     return null;
   }
@@ -20,7 +54,7 @@ function cacheGet(key) {
 
 function cacheSet(key, data) {
   cache.set(key, { at: Date.now(), data });
-  if (cache.size > 400) {
+  if (cache.size > 2500) {
     const first = cache.keys().next().value;
     cache.delete(first);
   }
@@ -39,12 +73,57 @@ function sanitizeQuery(q) {
     .slice(0, 120);
 }
 
+function sanitizeRegion(raw) {
+  const v = String(raw || 'US').trim().toUpperCase();
+  if (!/^[A-Z]{2}$/.test(v)) return 'US';
+  return v;
+}
+
+function mapOffers(block, link) {
+  const groups = [
+    ['flatrate', 'subscription'],
+    ['ads', 'free'],
+    ['free', 'free'],
+    ['rent', 'rent'],
+    ['buy', 'buy'],
+  ];
+  const seen = new Set();
+  const offers = [];
+  for (const [key, group] of groups) {
+    const list = Array.isArray(block?.[key]) ? block[key] : [];
+    for (const row of list) {
+      const id = Number(row.provider_id);
+      if (!id || seen.has(id)) continue;
+      seen.add(id);
+      const name = String(row.provider_name || '').slice(0, 80);
+      const home = PROVIDER_HOME[id] || link || '';
+      if (!name || !home) continue;
+      offers.push({
+        id,
+        name,
+        logo: typeof row.logo_path === 'string' ? row.logo_path : null,
+        url: home,
+        group,
+      });
+    }
+  }
+  return offers;
+}
+
+async function watchPayload(kind, id, region) {
+  const data = await fetchTMDB(`/${kind}/${id}/watch/providers`);
+  const block = data?.results?.[region] || data?.results?.US || {};
+  const link = typeof block.link === 'string' && /^https:\/\//i.test(block.link) ? block.link : '';
+  return { region, offers: mapOffers(block, link), link };
+}
+
 async function fetchTMDB(endpoint) {
   const TMDB_API_KEY = process.env.TMDB_API_KEY;
   if (!TMDB_API_KEY) {
     throw new Error('TMDB_API_KEY not configured');
   }
-  const cached = cacheGet(endpoint);
+  const ttl = endpoint.includes('/watch/providers') ? WATCH_TTL : CACHE_TTL;
+  const cached = cacheGet(endpoint, ttl);
   if (cached) return cached;
   const url = `${TMDB_BASE}${endpoint}${endpoint.includes('?') ? '&' : '?'}api_key=${TMDB_API_KEY}`;
   const res = await fetch(url, {
@@ -163,6 +242,30 @@ router.get('/tv/search', async (req, res) => {
   if (!q) return res.status(400).json({ error: 'Missing query parameter' });
   try {
     const data = await fetchTMDB(`/search/tv?query=${encodeURIComponent(q)}&include_adult=false`);
+    res.json(data);
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+router.get('/movie/:id/watch', async (req, res) => {
+  const id = sanitizeId(req.params.id);
+  if (!id) return res.status(400).json({ error: 'Invalid id' });
+  try {
+    const data = await watchPayload('movie', id, sanitizeRegion(req.query.region));
+    res.setHeader('Cache-Control', 'public, max-age=3600');
+    res.json(data);
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+router.get('/tv/:id/watch', async (req, res) => {
+  const id = sanitizeId(req.params.id);
+  if (!id) return res.status(400).json({ error: 'Invalid id' });
+  try {
+    const data = await watchPayload('tv', id, sanitizeRegion(req.query.region));
+    res.setHeader('Cache-Control', 'public, max-age=3600');
     res.json(data);
   } catch (e) {
     res.status(500).json({ error: e.message });

--- a/backend/server.js
+++ b/backend/server.js
@@ -143,6 +143,11 @@ import { createCapGateMiddleware, sendVerifyPage, requireGateUpgrade } from './m
 import { cleanupCapStore } from './cap/store.js';
 import { legalAcceptHandler, legalStatusHandler } from './legal/accept.js';
 import { redirectLegal, sendLegalPage } from './legal/pages.js';
+import {
+  copyrightReportHandler,
+  copyrightReportsAdminHandler,
+  copyrightReportLimiter,
+} from './api/copyright.js';
 
 const { createBareServer } = bareServerPkg;
 const SqliteStore = BetterSqlite3Session(session);
@@ -252,6 +257,8 @@ app.get('/privacy', redirectLegal('/privacy-policy'));
 app.get('/copyright', redirectLegal('/dmca'));
 app.get('/api/legal/status', legalStatusHandler);
 app.post('/api/legal/accept', legalAcceptHandler);
+app.post('/api/copyright/report', copyrightReportLimiter, copyrightReportHandler);
+app.get('/api/admin/copyright/reports', copyrightReportsAdminHandler);
 app.use('/cap', capRouter);
 app.use('/vendor/three', express.static(path.join(__dirname, '../node_modules/three/build'), { index: false, maxAge: '7d' }));
 app.use('/vendor/vanta', express.static(path.join(__dirname, '../node_modules/vanta/dist'), { index: false, maxAge: '7d' }));

--- a/backend/utils/client-ip.js
+++ b/backend/utils/client-ip.js
@@ -1,5 +1,13 @@
 export function getClientIP(req) {
-  let ip = req.headers['x-forwarded-for'] || req.socket?.remoteAddress || req.connection?.remoteAddress || null;
+  // cf-connecting-ip comes from cloudflare's edge, a client can't forge it.
+  // x-forwarded-for can be set by anyone hitting the origin directly, only
+  // fall back to it if there's no cf header to trust instead.
+  let ip =
+    req.headers['cf-connecting-ip'] ||
+    req.headers['x-forwarded-for'] ||
+    req.socket?.remoteAddress ||
+    req.connection?.remoteAddress ||
+    null;
   if (ip && typeof ip === 'string' && ip.includes(',')) ip = ip.split(',')[0].trim();
   if (ip && typeof ip === 'string' && ip.startsWith('::ffff:')) ip = ip.replace('::ffff:', '');
   return ip || null;

--- a/backend/utils/seo-meta.js
+++ b/backend/utils/seo-meta.js
@@ -13,11 +13,11 @@ export function isPeteZahHomeHost(host) {
 }
 
 export const EDU_SEO = {
-  title: "HypeStudy — Secure Study Platform for Students",
+  title: "HypeStudy — Private Research Browser",
   description:
-    "Create flashcards, take quizzes, track your progress with advanced analytics, and master any subject with confidence. Online learning tools for K-12, college, and lifelong learners.",
+    "A privacy-oriented browser for reading, research, and personal use. Browse with fewer interruptions when other hosts are filtered. Not a flashcard or quiz LMS.",
   keywords:
-    "study, flashcards, quiz, analytics, HypeStudy, learning, education, study tools, exam prep, student platform, online learning, academic success, tutoring, homework help, SAT prep, ACT prep, STEM education, curriculum, academic resources, e-learning",
+    "HypeStudy, private browser, research browser, reading, homework research, study, education, privacy, personal browsing, student research, K-12 resources, college reading",
   siteName: "HypeStudy",
   author: "HypeStudy",
   themeColor: "#f8f6f1",
@@ -26,27 +26,28 @@ export const EDU_SEO = {
   ogImage: "https://hypestudy.com/logo.png",
   ogImageWidth: "496",
   ogImageHeight: "503",
-  ogImageAlt: "HypeStudy Logo - Secure Study Platform",
+  ogImageAlt: "HypeStudy — private research browser",
   twitter: "@hypestudy",
   jsonLd: {
     "@context": "https://schema.org",
-    "@type": "EducationalOrganization",
+    "@type": "WebApplication",
     name: "HypeStudy",
+    applicationCategory: "BrowserApplication",
+    operatingSystem: "Web",
     description:
-      "Secure study platform offering flashcards, quizzes, analytics, and academic resources for students.",
+      "Privacy-oriented research browser for reading, homework, and personal browsing.",
     url: "https://hypestudy.com/",
     logo: "https://hypestudy.com/logo.png",
     image: "https://hypestudy.com/logo.png",
-    areaServed: "Worldwide",
   },
 };
 
 export const HOME_SEO = {
-  title: "PeteZah Games — Free Unblocked Games, Apps & Private Browser",
+  title: "PeteZah — Privacy Browser, Games, and the Open Web",
   description:
-    "Play free unblocked games, apps, movies, and music in a fast private browser. PeteZah Games is your all-in-one unblocked gaming and web hub — no downloads, works at school and work.",
+    "PeteZah is a privacy-oriented browser with HTML5 games, a licensed streaming-service movie directory, optional music overlay, and full-internet browsing. Use it lawfully.",
   keywords:
-    "PeteZah, PeteZah Games, unblocked games, free online games, unblocked apps, private browser, proxy browser, unblocked movies, free music, browser games, school games, unblocked at school, web games, HTML5 games",
+    "PeteZah, PeteZah Games, privacy browser, private browser, HTML5 games, online games, research browser, licensed streaming, movies directory, web browser, apps",
   siteName: "PeteZah Games",
   author: "PeteZah",
   themeColor: "#020810",
@@ -55,7 +56,7 @@ export const HOME_SEO = {
   ogImage: "https://petezahgames.com/og-share.png",
   ogImageWidth: "1200",
   ogImageHeight: "630",
-  ogImageAlt: "PeteZah Games — Free Unblocked Games and Private Browser",
+  ogImageAlt: "PeteZah — privacy browser and games",
   twitter: "@petezahgames",
   jsonLd: {
     "@context": "https://schema.org",
@@ -65,7 +66,7 @@ export const HOME_SEO = {
         name: "PeteZah Games",
         url: "https://petezahgames.com/",
         description:
-          "Free unblocked games, apps, and a private browser for school and everyday use.",
+          "Privacy-oriented browser with games, a licensed movie directory, and general web access.",
         image: {
           "@type": "ImageObject",
           url: "https://petezahgames.com/og-share.png",
@@ -85,7 +86,7 @@ export const HOME_SEO = {
         operatingSystem: "Web",
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
         description:
-          "A privacy-oriented browser with unblocked games, apps, movies, music, and AI tools.",
+          "A privacy-oriented browser with games, licensed streaming-service links, music overlay, and web access.",
         image: "https://petezahgames.com/og-share.png",
       },
       {
@@ -126,7 +127,7 @@ function stripSensitiveInlineScripts(html) {
     if (/type\s*=\s*["']application\/ld\+json["']/i.test(full)) return full;
     if (/src\s*=/i.test(full) && !body.trim()) return full;
     if (
-      /petezahgames|PeteZah|proxy browser|unblocked games|private browser/i.test(body) &&
+      /petezahgames|PeteZah|proxy browser|unblocked games|private browser|privacy browser/i.test(body) &&
       (/location\.hostname|seo\s*=|jsonLd|og:title|canonical/i.test(body) ||
         /petezahgames\.com/i.test(body))
     ) {
@@ -194,7 +195,7 @@ export function applySeoToHtml(html, host) {
   if (home) {
     out = out.replace(
       /<div class="education-is-key"[\s\S]*?<\/div>/gi,
-      `<div class="education-is-key" aria-hidden="true"><h1>PeteZah Games</h1><p>Free unblocked games, private browser, apps, movies, and music online.</p></div>`
+      `<div class="education-is-key" aria-hidden="true"><h1>PeteZah</h1><p>Privacy-oriented browser with games, a licensed movie directory, and general web access.</p></div>`
     );
   }
 

--- a/index.html
+++ b/index.html
@@ -52,18 +52,18 @@ If you want to make the website better, the repository is open source, and my dm
     crossorigin="anonymous"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <title>HypeStudy</title>
+    <title>HypeStudy — Private Research Browser</title>
     <meta
       name="title"
-      content="HypeStudy"
+      content="HypeStudy — Private Research Browser"
     />
     <meta
       name="description"
-      content="Create flashcards, take quizzes, track your progress with advanced analytics, and master any subject with confidence."
+      content="A privacy-oriented browser for reading, research, and personal use. Browse with fewer interruptions when other hosts are filtered."
     />
     <meta
       name="keywords"
-      content="Study, Flashcards, Quiz, Analytics, HypeStudy, Learning, Education, Study Tools, Exam Prep, Student Platform, Secure Study, Online Learning, Study Platform, Test Preparation, Academic Success"
+      content="HypeStudy, private browser, research browser, reading, homework research, study, education, privacy, personal browsing"
     />
     <meta name="author" content="HypeStudy" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
@@ -79,11 +79,11 @@ If you want to make the website better, the repository is open source, and my dm
     <meta property="og:type" content="website" />
     <meta
       property="og:title"
-      content="HypeStudy — Secure Study Platform for Students"
+      content="HypeStudy — Private Research Browser"
     />
     <meta
       property="og:description"
-      content="Secure, animated, and modern study platform. Master your subjects with interactive flashcards, dynamic quizzes, comprehensive analytics, and powerful study tools."
+      content="Privacy-oriented browser for reading, research, homework, and personal browsing."
     />
     <meta property="og:image" content="/logo.png" />
     <meta property="og:image:width" content="1200" />
@@ -96,16 +96,16 @@ If you want to make the website better, the repository is open source, and my dm
     <meta name="twitter:creator" content="@hypestudy" />
     <meta
       name="twitter:title"
-      content="HypeStudy — Secure Study Platform for Students"
+      content="HypeStudy — Private Research Browser"
     />
     <meta
       name="twitter:description"
-      content="Secure, animated, and modern study platform. Interactive flashcards, quizzes, analytics, and everything you need to excel in your studies."
+      content="Privacy-oriented browser for reading, research, homework, and personal browsing."
     />
     <meta name="twitter:image" content="/logo.png" />
     <meta
       name="twitter:image:alt"
-      content="HypeStudy Logo - Secure Study Platform"
+      content="HypeStudy — private research browser"
     />
     <meta name="application-name" content="HypeStudy" />
     <meta name="apple-mobile-web-app-title" content="HypeStudy" />
@@ -153,11 +153,10 @@ If you want to make the website better, the repository is open source, and my dm
     <div id="root"></div>
 
     <div class="education-is-key" aria-hidden="true">
-      <h1>Educational Resources and Online Learning Platform</h1>
+      <h1>Private research and reading browser</h1>
       <p>
-        Comprehensive education platform for students, teachers, and lifelong
-        learners. Access online courses, study materials, exam preparation
-        resources, and interactive learning tools.
+        Privacy-oriented browsing for reading, homework research, and personal
+        use. Access the web with fewer interruptions. Not a flashcard or quiz LMS.
       </p>
       <section>
         <h2>Academic Subjects</h2>
@@ -171,12 +170,9 @@ If you want to make the website better, the repository is open source, and my dm
       <section>
         <h2>Educational Services</h2>
         <p>
-          Online courses, college credit, exam preparation, test prep, tutoring,
-          homework help, study guides, practice tests, educational videos,
-          interactive lessons, learning resources, curriculum development,
-          academic support, student success, teacher resources, educational
-          technology, e-learning, distance education, virtual classroom, online
-          tutoring, academic coaching
+          Use this browser to research homework, read study guides, watch
+          educational videos, and open academic resources on the open web.
+          We do not operate our own course catalog, tutoring service, or LMS.
         </p>
       </section>
       <section>
@@ -191,19 +187,15 @@ If you want to make the website better, the repository is open source, and my dm
       <section>
         <h2>Test Preparation</h2>
         <p>
-          SAT prep, ACT prep, GRE prep, GMAT prep, LSAT prep, MCAT prep, AP
-          courses, Advanced Placement, standardized tests, college entrance
-          exams, professional certification exams, state assessments, final
-          exams, midterms
+          SAT, ACT, GRE, GMAT, LSAT, MCAT, AP, and other exam names you may look
+          up while studying. This browser does not sell test-prep courses.
         </p>
       </section>
       <section>
         <h3>Learning Methods</h3>
         <p>
-          Interactive learning, video lessons, practice quizzes, flashcards,
-          study notes, educational games, adaptive learning, personalized
-          education, self-paced learning, collaborative learning, project-based
-          learning, STEM education, critical thinking, problem solving
+          Reading, writing, research notes, educational videos you open on the
+          open web, and personal study while using this private browser.
         </p>
       </section>
     </div>
@@ -211,11 +203,10 @@ If you want to make the website better, the repository is open source, and my dm
     <script type="module" src="/src/main.tsx"></script>
     <script src="https://cdn.jsdelivr.net/gh/docklib/partners@master/partner-a11f34f2.js"></script>
     <div class="education-is-key" aria-hidden="true">
-      <h1>Educational Resources and Online Learning Platform</h1>
+      <h1>Private research and reading browser</h1>
       <p>
-        Comprehensive education platform for students, teachers, and lifelong
-        learners. Access online courses, study materials, exam preparation
-        resources, and interactive learning tools.
+        Privacy-oriented browsing for reading, homework research, and personal
+        use. Access the web with fewer interruptions. Not a flashcard or quiz LMS.
       </p>
       <section>
         <h2>Academic Subjects</h2>
@@ -229,12 +220,9 @@ If you want to make the website better, the repository is open source, and my dm
       <section>
         <h2>Educational Services</h2>
         <p>
-          Online courses, college credit, exam preparation, test prep, tutoring,
-          homework help, study guides, practice tests, educational videos,
-          interactive lessons, learning resources, curriculum development,
-          academic support, student success, teacher resources, educational
-          technology, e-learning, distance education, virtual classroom, online
-          tutoring, academic coaching
+          Use this browser to research homework, read study guides, watch
+          educational videos, and open academic resources on the open web.
+          We do not operate our own course catalog, tutoring service, or LMS.
         </p>
       </section>
       <section>
@@ -249,28 +237,23 @@ If you want to make the website better, the repository is open source, and my dm
       <section>
         <h2>Test Preparation</h2>
         <p>
-          SAT prep, ACT prep, GRE prep, GMAT prep, LSAT prep, MCAT prep, AP
-          courses, Advanced Placement, standardized tests, college entrance
-          exams, professional certification exams, state assessments, final
-          exams, midterms
+          SAT, ACT, GRE, GMAT, LSAT, MCAT, AP, and other exam names you may look
+          up while studying. This browser does not sell test-prep courses.
         </p>
       </section>
       <section>
         <h3>Learning Methods</h3>
         <p>
-          Interactive learning, video lessons, practice quizzes, flashcards,
-          study notes, educational games, adaptive learning, personalized
-          education, self-paced learning, collaborative learning, project-based
-          learning, STEM education, critical thinking, problem solving
+          Reading, writing, research notes, educational videos you open on the
+          open web, and personal study while using this private browser.
         </p>
       </section>
     </div>
     <div class="education-is-key" aria-hidden="true">
-      <h1>Educational Resources and Online Learning Platform</h1>
+      <h1>Private research and reading browser</h1>
       <p>
-        Comprehensive education platform for students, teachers, and lifelong
-        learners. Access online courses, study materials, exam preparation
-        resources, and interactive learning tools.
+        Privacy-oriented browsing for reading, homework research, and personal
+        use. Access the web with fewer interruptions. Not a flashcard or quiz LMS.
       </p>
       <section>
         <h2>Academic Subjects</h2>
@@ -284,12 +267,9 @@ If you want to make the website better, the repository is open source, and my dm
       <section>
         <h2>Educational Services</h2>
         <p>
-          Online courses, college credit, exam preparation, test prep, tutoring,
-          homework help, study guides, practice tests, educational videos,
-          interactive lessons, learning resources, curriculum development,
-          academic support, student success, teacher resources, educational
-          technology, e-learning, distance education, virtual classroom, online
-          tutoring, academic coaching
+          Use this browser to research homework, read study guides, watch
+          educational videos, and open academic resources on the open web.
+          We do not operate our own course catalog, tutoring service, or LMS.
         </p>
       </section>
       <section>
@@ -304,28 +284,23 @@ If you want to make the website better, the repository is open source, and my dm
       <section>
         <h2>Test Preparation</h2>
         <p>
-          SAT prep, ACT prep, GRE prep, GMAT prep, LSAT prep, MCAT prep, AP
-          courses, Advanced Placement, standardized tests, college entrance
-          exams, professional certification exams, state assessments, final
-          exams, midterms
+          SAT, ACT, GRE, GMAT, LSAT, MCAT, AP, and other exam names you may look
+          up while studying. This browser does not sell test-prep courses.
         </p>
       </section>
       <section>
         <h3>Learning Methods</h3>
         <p>
-          Interactive learning, video lessons, practice quizzes, flashcards,
-          study notes, educational games, adaptive learning, personalized
-          education, self-paced learning, collaborative learning, project-based
-          learning, STEM education, critical thinking, problem solving
+          Reading, writing, research notes, educational videos you open on the
+          open web, and personal study while using this private browser.
         </p>
       </section>
     </div>
     <div class="education-is-key" aria-hidden="true">
-      <h1>Educational Resources and Online Learning Platform</h1>
+      <h1>Private research and reading browser</h1>
       <p>
-        Comprehensive education platform for students, teachers, and lifelong
-        learners. Access online courses, study materials, exam preparation
-        resources, and interactive learning tools.
+        Privacy-oriented browsing for reading, homework research, and personal
+        use. Access the web with fewer interruptions. Not a flashcard or quiz LMS.
       </p>
       <section>
         <h2>Academic Subjects</h2>
@@ -339,12 +314,9 @@ If you want to make the website better, the repository is open source, and my dm
       <section>
         <h2>Educational Services</h2>
         <p>
-          Online courses, college credit, exam preparation, test prep, tutoring,
-          homework help, study guides, practice tests, educational videos,
-          interactive lessons, learning resources, curriculum development,
-          academic support, student success, teacher resources, educational
-          technology, e-learning, distance education, virtual classroom, online
-          tutoring, academic coaching
+          Use this browser to research homework, read study guides, watch
+          educational videos, and open academic resources on the open web.
+          We do not operate our own course catalog, tutoring service, or LMS.
         </p>
       </section>
       <section>
@@ -359,28 +331,23 @@ If you want to make the website better, the repository is open source, and my dm
       <section>
         <h2>Test Preparation</h2>
         <p>
-          SAT prep, ACT prep, GRE prep, GMAT prep, LSAT prep, MCAT prep, AP
-          courses, Advanced Placement, standardized tests, college entrance
-          exams, professional certification exams, state assessments, final
-          exams, midterms
+          SAT, ACT, GRE, GMAT, LSAT, MCAT, AP, and other exam names you may look
+          up while studying. This browser does not sell test-prep courses.
         </p>
       </section>
       <section>
         <h3>Learning Methods</h3>
         <p>
-          Interactive learning, video lessons, practice quizzes, flashcards,
-          study notes, educational games, adaptive learning, personalized
-          education, self-paced learning, collaborative learning, project-based
-          learning, STEM education, critical thinking, problem solving
+          Reading, writing, research notes, educational videos you open on the
+          open web, and personal study while using this private browser.
         </p>
       </section>
     </div>
     <div class="education-is-key" aria-hidden="true">
-      <h1>Educational Resources and Online Learning Platform</h1>
+      <h1>Private research and reading browser</h1>
       <p>
-        Comprehensive education platform for students, teachers, and lifelong
-        learners. Access online courses, study materials, exam preparation
-        resources, and interactive learning tools.
+        Privacy-oriented browsing for reading, homework research, and personal
+        use. Access the web with fewer interruptions. Not a flashcard or quiz LMS.
       </p>
       <section>
         <h2>Academic Subjects</h2>
@@ -394,12 +361,9 @@ If you want to make the website better, the repository is open source, and my dm
       <section>
         <h2>Educational Services</h2>
         <p>
-          Online courses, college credit, exam preparation, test prep, tutoring,
-          homework help, study guides, practice tests, educational videos,
-          interactive lessons, learning resources, curriculum development,
-          academic support, student success, teacher resources, educational
-          technology, e-learning, distance education, virtual classroom, online
-          tutoring, academic coaching
+          Use this browser to research homework, read study guides, watch
+          educational videos, and open academic resources on the open web.
+          We do not operate our own course catalog, tutoring service, or LMS.
         </p>
       </section>
       <section>
@@ -414,19 +378,15 @@ If you want to make the website better, the repository is open source, and my dm
       <section>
         <h2>Test Preparation</h2>
         <p>
-          SAT prep, ACT prep, GRE prep, GMAT prep, LSAT prep, MCAT prep, AP
-          courses, Advanced Placement, standardized tests, college entrance
-          exams, professional certification exams, state assessments, final
-          exams, midterms
+          SAT, ACT, GRE, GMAT, LSAT, MCAT, AP, and other exam names you may look
+          up while studying. This browser does not sell test-prep courses.
         </p>
       </section>
       <section>
         <h3>Learning Methods</h3>
         <p>
-          Interactive learning, video lessons, practice quizzes, flashcards,
-          study notes, educational games, adaptive learning, personalized
-          education, self-paced learning, collaborative learning, project-based
-          learning, STEM education, critical thinking, problem solving
+          Reading, writing, research notes, educational videos you open on the
+          open web, and personal study while using this private browser.
         </p>
       </section>
     </div>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "petezah",
   "version": "2.0.0",
-  "description": "A web proxy to bypass various filters. Report questions to https://discord.gg/cYjHFDguxS.",
+  "description": "Privacy-oriented browser with games, licensed-service movie directory, and general web access.",
   "author": "PeteZah",
   "license": "AGPL-3.0-only",
   "private": true,

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,7 +3,7 @@
   "short_name": "PeteZah",
   "start_url": "/",
   "display": "standalone",
-  "description": "Access the internet uncensored.  Game on.",
+  "description": "A privacy-oriented browser for games and the open web.",
   "background_color": "#0A1D37",
   "theme_color": "#0A1D37",
   "icons": [

--- a/public/static/index.html
+++ b/public/static/index.html
@@ -388,7 +388,7 @@
 
     <script>
       const phrases = [
-        'PeteZah best unblocked games site!',
+        'PeteZah privacy browser',
         'https://petezahgames.com',
         'Credits to Brunys and Voucan for proxy help',
         'just had a major update ¯\\_(ツ)_/¯',

--- a/public/verify.html
+++ b/public/verify.html
@@ -280,7 +280,8 @@
         I agree to the
         <a href="/terms" target="_blank" rel="noopener">Terms</a>,
         <a href="/privacy-policy" target="_blank" rel="noopener">Privacy Policy</a>, and
-        <a href="/dmca" target="_blank" rel="noopener">DMCA Policy</a>.
+        <a href="/dmca" target="_blank" rel="noopener">Copyright Policy</a>.
+        You must be 13 or older.
       </span>
     </label>
     <button type="button" class="continue" id="continue" disabled>

--- a/src/components/AccountPage.tsx
+++ b/src/components/AccountPage.tsx
@@ -355,7 +355,7 @@ const NAV: { id: Section; label: string; icon: any; adminOnly?: boolean }[] = [
   { id: "get-links",  label: "Get Links",   icon: Link2 },
   { id: "achievements", label: "Achievements", icon: Trophy },
   { id: "appearance", label: "Appearance",  icon: Palette },
-  { id: "cloaking",   label: "Cloaking",    icon: Shield },
+  { id: "cloaking",   label: "Tab appearance", icon: Shield },
   { id: "behavior",   label: "Behavior",    icon: Sliders },
   { id: "shortcuts",  label: "Shortcuts",   icon: Keyboard },
   { id: "data",       label: "Data",        icon: Download },
@@ -541,6 +541,7 @@ export default function AccountPage({ onNavigate }: { onNavigate: (url: string) 
   const [gameLive, setGameLive] = useState<any>(null);
   const [excludedGames, setExcludedGames] = useState<any[]>([]);
   const [excludedLoading, setExcludedLoading] = useState(false);
+  const [copyrightReports, setCopyrightReports] = useState<any[]>([]);
   const [resendBusy, setResendBusy] = useState(false);
 
   function hydrateProfile(u: AuthUser) {
@@ -950,12 +951,14 @@ export default function AccountPage({ onNavigate }: { onNavigate: (url: string) 
         fetch(url, { credentials: "include" }).then((r) => r.json()),
         fetch("/api/admin/game-live", { credentials: "include" }).then((r) => r.json()),
         fetch("/api/admin/games/excluded", { credentials: "include" }).then((r) => r.json()),
+        fetch("/api/admin/copyright/reports", { credentials: "include" }).then((r) => r.json()).catch(() => ({})),
       ])
-        .then(([stats, live, excl]) => {
+        .then(([stats, live, excl, reports]) => {
           if (cancelled) return;
           setGameStats(stats);
           setGameLive(live);
           setExcludedGames(Array.isArray(excl?.excluded) ? excl.excluded : []);
+          setCopyrightReports(Array.isArray(reports?.reports) ? reports.reports : []);
         })
         .catch(() => {
           if (!cancelled) {
@@ -1131,7 +1134,7 @@ export default function AccountPage({ onNavigate }: { onNavigate: (url: string) 
     e.preventDefault();
     setAuthErr(""); setAuthOk("");
     if (authMode === "signup" && !acceptedLegal) {
-      setAuthErr("Agree to the Terms, Privacy Policy, and DMCA Policy to create an account.");
+      setAuthErr("Agree to the Terms, Privacy Policy, and Copyright Policy to create an account.");
       return;
     }
     if (authMode === "signup") {
@@ -1995,7 +1998,8 @@ export default function AccountPage({ onNavigate }: { onNavigate: (url: string) 
                 I agree to the{" "}
                 <a href="/terms" target="_blank" rel="noopener noreferrer" style={{ color: C.text }} onClick={(e) => e.stopPropagation()}>Terms</a>,{" "}
                 <a href="/privacy-policy" target="_blank" rel="noopener noreferrer" style={{ color: C.text }} onClick={(e) => e.stopPropagation()}>Privacy</a>, and{" "}
-                <a href="/dmca" target="_blank" rel="noopener noreferrer" style={{ color: C.text }} onClick={(e) => e.stopPropagation()}>DMCA</a>.
+                <a href="/dmca" target="_blank" rel="noopener noreferrer" style={{ color: C.text }} onClick={(e) => e.stopPropagation()}>Copyright Policy</a>.
+                You must be 13 or older. If you are under 18, a parent or guardian should review these terms.
               </span>
             </label>
           )}
@@ -2540,8 +2544,8 @@ export default function AccountPage({ onNavigate }: { onNavigate: (url: string) 
             {section === "get-links" && (
               <div style={{ maxWidth: "520px" }}>
                 <h2 style={{ fontSize: 15, fontWeight: 700, color: C.text, margin: "0 0 3px" }}>Get Links</h2>
-                <p style={{ fontSize: 11, color: C.textSub, margin: "0 0 18px" }}>
-                  Verified accounts get {linksStatus?.weeklyLimit ?? 2} links per week. This week&apos;s claims stay visible until the week resets.
+                <p style={{ fontSize: 11, color: C.textSub, margin: "0 0 18px", lineHeight: 1.5 }}>
+                  If one of our domains is filtered on a network, verified accounts can request a continuity link for that environment. {linksStatus?.weeklyLimit ?? 2} links per week. This is so you can keep reaching our Service — not permission to break a school or workplace policy.
                 </p>
 
                 {linksLoading && !linksStatus ? (
@@ -2686,7 +2690,7 @@ export default function AccountPage({ onNavigate }: { onNavigate: (url: string) 
                       Request a link
                     </p>
                     <div style={{ display: "flex", flexDirection: "column", gap: 10, marginBottom: 16 }}>
-                      <label style={{ display: "block", fontSize: 10, fontWeight: 600, letterSpacing: "0.08em", textTransform: "uppercase", color: C.textMuted }}>Blocker</label>
+                      <label style={{ display: "block", fontSize: 10, fontWeight: 600, letterSpacing: "0.08em", textTransform: "uppercase", color: C.textMuted }}>Network filter</label>
                       <select
                         value={selectedBlocker}
                         onChange={(e) => setSelectedBlocker(e.target.value)}
@@ -2779,8 +2783,10 @@ export default function AccountPage({ onNavigate }: { onNavigate: (url: string) 
 
             {section === "cloaking" && (
               <div style={{ maxWidth: "440px" }}>
-                <h2 style={{ fontSize: "15px", fontWeight: 700, color: C.text, margin: "0 0 3px" }}>Cloaking</h2>
-                <p style={{ fontSize: "11px", color: C.textSub, margin: "0 0 20px" }}>Disguise the tab to look like another site</p>
+                <h2 style={{ fontSize: "15px", fontWeight: 700, color: C.text, margin: "0 0 3px" }}>Tab appearance</h2>
+                <p style={{ fontSize: "11px", color: C.textSub, margin: "0 0 20px", lineHeight: 1.5 }}>
+                  Optional tab title and icon — the same kind of customization browsers allow. This does not hide activity from network monitoring.
+                </p>
 
                 <p style={{ fontSize: "10px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: C.textMuted, margin: "0 0 8px" }}>Quick Presets</p>
                 <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "6px", marginBottom: "18px" }}>
@@ -2803,14 +2809,14 @@ export default function AccountPage({ onNavigate }: { onNavigate: (url: string) 
                 </div>
 
                 <div style={{ display: "flex", flexDirection: "column", gap: "10px", marginBottom: "20px" }}>
-                  <Field label="Custom tab title" value={s.siteTitle || ""} onChange={(e: any) => setVal("siteTitle", e.target.value)} placeholder="e.g. Google Classroom" />
+                  <Field label="Custom tab title" value={s.siteTitle || ""} onChange={(e: any) => setVal("siteTitle", e.target.value)} placeholder="e.g. Research" />
                   <Field label="Custom favicon URL" value={s.siteLogo || ""} onChange={(e: any) => setVal("siteLogo", e.target.value)} placeholder="https://..." icon={Lock} />
                 </div>
 
                 <Divider />
-                <p style={{ fontSize: "10px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: C.textMuted, margin: "14px 0 6px" }}>About:Blank</p>
+                <p style={{ fontSize: "10px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: C.textMuted, margin: "14px 0 6px" }}>Blank window</p>
                 <p style={{ fontSize: "11px", color: C.textSub, margin: "0 0 10px" }}>
-                  Open the site disguised inside an about:blank popup. Any PeteZah link ending in <code style={{ fontSize: 10 }}>/#blank</code> does this automatically.
+                  Open this Service in a blank browser window. Links ending in <code style={{ fontSize: 10 }}>/#blank</code> do the same. This is a windowing preference, not a claim that activity is hidden.
                 </p>
                 <button onClick={openAboutBlank} style={{
                   display: "flex", alignItems: "center", gap: "8px", padding: "9px 16px", borderRadius: "8px", marginBottom: "18px",
@@ -2823,7 +2829,7 @@ export default function AccountPage({ onNavigate }: { onNavigate: (url: string) 
 
                 <Divider />
                 <p style={{ fontSize: "10px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: C.textMuted, margin: "14px 0 6px" }}>Panic Key</p>
-                <p style={{ fontSize: "11px", color: C.textSub, margin: "0 0 10px" }}>Press a key to instantly redirect the browser</p>
+                <p style={{ fontSize: "11px", color: C.textSub, margin: "0 0 10px" }}>Keyboard shortcut to leave this tab quickly</p>
                 <div style={{ display: "grid", gridTemplateColumns: "80px 1fr", gap: "10px", marginBottom: "4px" }}>
                   <Field label="Key" value={s.panicKey || ""} onChange={(e: any) => setVal("panicKey", e.target.value)} placeholder="q" maxLength={1} icon={KeyRound} />
                   <Field label="Redirect URL" value={s.panicUrl || ""} onChange={(e: any) => setVal("panicUrl", e.target.value)} placeholder="https://google.com" icon={Lock} />
@@ -3917,6 +3923,31 @@ export default function AccountPage({ onNavigate }: { onNavigate: (url: string) 
                     ))}
                   </div>
                 )}
+
+                <p style={{ fontSize: 10, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: C.textMuted, margin: "18px 0 8px" }}>
+                  Copyright reports ({copyrightReports.length})
+                </p>
+                {!copyrightReports.length ? (
+                  <p style={{ fontSize: 12, color: C.textMuted, margin: 0 }}>No reports yet. After a valid notice, suspend the game from the catalog.</p>
+                ) : (
+                  <div style={{ display: "flex", flexDirection: "column", gap: 6, maxHeight: "32vh", overflowY: "auto" }}>
+                    {copyrightReports.map((r: any) => (
+                      <div key={r.id} style={{
+                        padding: "10px 12px", borderRadius: 8, background: C.surface, border: `1px solid ${C.border}`,
+                      }}>
+                        <p style={{ margin: 0, fontSize: 12, color: C.text, fontWeight: 650 }}>
+                          {r.title || r.targetId || "Untitled"} · {r.status || "open"}
+                        </p>
+                        <p style={{ margin: "4px 0 0", fontSize: 10, color: C.textMuted }}>
+                          {r.email || "no email"} · {r.work || "work unspecified"} · {r.createdAt ? new Date(r.createdAt).toLocaleString() : ""}
+                        </p>
+                        <p style={{ margin: "6px 0 0", fontSize: 11, color: C.textSub, lineHeight: 1.4, whiteSpace: "pre-wrap" }}>
+                          {r.statement}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                )}
               </div>
             )}
 
@@ -3927,7 +3958,7 @@ export default function AccountPage({ onNavigate }: { onNavigate: (url: string) 
                   Link Stats
                 </h2>
                 <p style={{ fontSize: 11, color: C.textSub, margin: "0 0 16px" }}>
-                  Distribution across blockers · refreshes every 15s
+                  Distribution across continuity-link pools · refreshes every 15s
                 </p>
                 {linkStatsLoading && !linkStats ? (
                   <div style={{ display: "flex", justifyContent: "center", padding: 40 }}>
@@ -4196,8 +4227,8 @@ export default function AccountPage({ onNavigate }: { onNavigate: (url: string) 
                   </button>
                 </div>
                 <p style={{ margin: "0 0 14px", fontSize: 12, color: C.textSub, lineHeight: 1.55, overflowWrap: "anywhere", wordBreak: "break-word" }}>
-                  PeteZah is a glass browser built for school-friendly browsing, games, music, and more.
-                  Huge thanks to the open projects that make the stack possible.
+                  PeteZah is a privacy-oriented browser with games, a licensed movie directory, optional music overlay, and general web access.
+                  Thanks to the open projects that make the stack possible.
                 </p>
                 <div style={{ display: "flex", flexDirection: "column", gap: 8, marginBottom: 16 }}>
                   {[
@@ -4222,7 +4253,7 @@ export default function AccountPage({ onNavigate }: { onNavigate: (url: string) 
                   {[
                     ["/terms", "Terms of Service"],
                     ["/privacy-policy", "Privacy Policy"],
-                    ["/dmca", "DMCA"],
+                    ["/dmca", "Copyright Policy"],
                   ].map(([href, label]) => (
                     <a
                       key={href}

--- a/src/components/AccountPage.tsx
+++ b/src/components/AccountPage.tsx
@@ -2064,6 +2064,7 @@ export default function AccountPage({ onNavigate }: { onNavigate: (url: string) 
       }}
     >
       <motion.div
+        className="account-settings-nav"
         initial={{ x: -28, opacity: 0 }}
         animate={{ x: 0, opacity: 1 }}
         transition={{ duration: 0.45, ease: [0.22, 1, 0.36, 1] }}
@@ -2081,7 +2082,7 @@ export default function AccountPage({ onNavigate }: { onNavigate: (url: string) 
           overflow: "hidden",
         }}
       >
-        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: "8px", marginBottom: "16px", paddingBottom: "14px", borderBottom: `1px solid ${C.border}` }}>
+        <div className="account-settings-nav-header" style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: "8px", marginBottom: "16px", paddingBottom: "14px", borderBottom: `1px solid ${C.border}` }}>
           <div style={{ position: "relative" }}>
             <div style={{
               width: "46px", height: "46px", borderRadius: "13px", overflow: "hidden",
@@ -2117,7 +2118,7 @@ export default function AccountPage({ onNavigate }: { onNavigate: (url: string) 
           </div>
         </div>
 
-        <nav style={{ flex: 1, minHeight: 0, overflowY: "auto", display: "flex", flexDirection: "column", gap: "2px", scrollbarWidth: "thin" }}>
+        <nav className="account-settings-nav-list" style={{ flex: 1, minHeight: 0, overflowY: "auto", display: "flex", flexDirection: "column", gap: "2px", scrollbarWidth: "thin" }}>
           {visibleSections.map(({ id, label, icon: Icon }, idx) => {
             const active = section === id;
             return (
@@ -2145,7 +2146,7 @@ export default function AccountPage({ onNavigate }: { onNavigate: (url: string) 
           })}
         </nav>
 
-        <button onClick={signout} style={{
+        <button onClick={signout} className="account-settings-signout" style={{
           display: "flex", alignItems: "center", gap: "7px", padding: "8px 10px", borderRadius: "7px",
           background: "transparent", border: `1px solid transparent`,
           color: C.textMuted, fontSize: "11px", fontWeight: 500, cursor: "pointer", marginTop: "6px", transition: "all 0.12s",
@@ -2156,7 +2157,7 @@ export default function AccountPage({ onNavigate }: { onNavigate: (url: string) 
         </button>
       </motion.div>
 
-      <div style={{
+      <div className="account-settings-content" style={{
         flex: 1,
         overflowY: "auto",
         padding: "26px 30px",

--- a/src/components/ArcBrowser.tsx
+++ b/src/components/ArcBrowser.tsx
@@ -8,6 +8,7 @@ import Toolbar from "@/components/BrowserToolbar";
 import ContentArea from "@/components/ContentArea";
 import StatusBar from "@/components/StatusBar";
 import DiscordPopup from "@/components/DiscordPopup";
+import LegalTermsPopup from "@/components/LegalTermsPopup";
 import VantaBackground from "@/components/VantaBackground";
 import DebugHud from "@/components/DebugHud";
 import HorizontalTabBar from "@/components/HorizontalTabBar";
@@ -398,6 +399,7 @@ export default function ArcBrowser() {
           </div>
         </main>
       </div>
+      <LegalTermsPopup />
       <DiscordPopup />
       <GlobalAnnouncement />
       <InspectOverlay

--- a/src/components/ContentArea.tsx
+++ b/src/components/ContentArea.tsx
@@ -1258,6 +1258,7 @@ function TabPane({
         <GameViewerPage
           url={gameUrl}
           title={gameTitle}
+          gameId={params.get("gid")}
           onBack={() => onNavigate("petezah://games")}
         />
       </div>

--- a/src/components/GameViewerPage.tsx
+++ b/src/components/GameViewerPage.tsx
@@ -10,6 +10,7 @@ import {
   GripHorizontal,
   Volume2,
   VolumeX,
+  Flag,
 } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useInterstitialUnlock, InterstitialOverlay } from "./InterstitialAdGate";
@@ -21,6 +22,7 @@ import { getSiteOrigin } from "@/lib/siteOrigin";
 interface GameViewerPageProps {
   url: string;
   title?: string;
+  gameId?: string | null;
   onBack?: () => void;
 }
 
@@ -143,6 +145,7 @@ function applyMuteToFrame(iframe: HTMLIFrameElement | null, muted: boolean) {
 export default function GameViewerPage({
   url,
   title,
+  gameId,
   onBack,
 }: GameViewerPageProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -154,6 +157,12 @@ export default function GameViewerPage({
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [controlsVisible, setControlsVisible] = useState(true);
   const [muted, setMuted] = useState(false);
+  const [reportOpen, setReportOpen] = useState(false);
+  const [reportEmail, setReportEmail] = useState("");
+  const [reportWork, setReportWork] = useState("");
+  const [reportStatement, setReportStatement] = useState("");
+  const [reportBusy, setReportBusy] = useState(false);
+  const [reportStatus, setReportStatus] = useState("");
   const { unlocked, phase, finishLoading } = useInterstitialUnlock("game");
   const useProxy = needsScramjetProxy(url);
   const displayTitle = title?.trim() || "Game";
@@ -461,6 +470,9 @@ export default function GameViewerPage({
                 >
                   {muted ? <VolumeX size={12} /> : <Volume2 size={12} />}
                 </ControlBtn>
+                <ControlBtn onClick={() => setReportOpen(true)} title="Report copyright issue">
+                  <Flag size={12} />
+                </ControlBtn>
                 <ControlBtn onClick={openExternal} title="Open in new tab">
                   <ExternalLink size={12} />
                 </ControlBtn>
@@ -519,6 +531,143 @@ export default function GameViewerPage({
             >
               <Eye size={11} /> Show Controls
             </motion.button>
+          )}
+        </AnimatePresence>
+
+        <AnimatePresence>
+          {reportOpen && (
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              style={{
+                position: "absolute",
+                inset: 0,
+                zIndex: 80,
+                display: "flex",
+                alignItems: "flex-end",
+                justifyContent: "center",
+                padding: 16,
+                background: "hsla(220, 40%, 4%, 0.55)",
+              }}
+              onClick={() => !reportBusy && setReportOpen(false)}
+            >
+              <motion.form
+                initial={{ y: 18, opacity: 0 }}
+                animate={{ y: 0, opacity: 1 }}
+                exit={{ y: 12, opacity: 0 }}
+                onClick={(e) => e.stopPropagation()}
+                onSubmit={async (e) => {
+                  e.preventDefault();
+                  if (reportBusy) return;
+                  setReportBusy(true);
+                  setReportStatus("");
+                  try {
+                    const r = await fetch("/api/copyright/report", {
+                      method: "POST",
+                      credentials: "include",
+                      headers: { "Content-Type": "application/json" },
+                      body: JSON.stringify({
+                        targetType: "game",
+                        targetId: gameId || "",
+                        url,
+                        title: displayTitle,
+                        email: reportEmail,
+                        work: reportWork,
+                        statement: reportStatement,
+                      }),
+                    });
+                    const d = await r.json().catch(() => ({}));
+                    if (!r.ok) {
+                      setReportStatus(d.error || "Could not send. Try again.");
+                      setReportBusy(false);
+                      return;
+                    }
+                    setReportStatus("Received. We review complete notices and disable access when required.");
+                    setTimeout(() => setReportOpen(false), 1400);
+                  } catch {
+                    setReportStatus("Network error. Please try again.");
+                  } finally {
+                    setReportBusy(false);
+                  }
+                }}
+                style={{
+                  width: "100%",
+                  maxWidth: 420,
+                  borderRadius: 16,
+                  padding: "16px 16px 14px",
+                  background: "hsla(220, 28%, 10%, 0.96)",
+                  border: "1px solid hsla(210, 30%, 80%, 0.14)",
+                  color: "hsla(210, 20%, 96%, 0.95)",
+                }}
+              >
+                <p style={{ margin: "0 0 4px", fontSize: 13, fontWeight: 700 }}>Copyright report</p>
+                <p style={{ margin: "0 0 12px", fontSize: 11, lineHeight: 1.45, color: "hsla(210, 14%, 70%, 0.8)" }}>
+                  For rights holders. Describe the work and where it appears. Complete legal notices can also be emailed — see our Copyright Policy.
+                </p>
+                <input
+                  value={reportEmail}
+                  onChange={(e) => setReportEmail(e.target.value)}
+                  placeholder="Contact email"
+                  type="email"
+                  style={{
+                    width: "100%", boxSizing: "border-box", marginBottom: 8, padding: "8px 10px",
+                    borderRadius: 8, border: "1px solid hsla(210, 30%, 80%, 0.14)", background: "hsla(220, 28%, 12%, 0.6)",
+                    color: "inherit", fontSize: 12, outline: "none",
+                  }}
+                />
+                <input
+                  value={reportWork}
+                  onChange={(e) => setReportWork(e.target.value)}
+                  placeholder="Copyrighted work (title / owner)"
+                  style={{
+                    width: "100%", boxSizing: "border-box", marginBottom: 8, padding: "8px 10px",
+                    borderRadius: 8, border: "1px solid hsla(210, 30%, 80%, 0.14)", background: "hsla(220, 28%, 12%, 0.6)",
+                    color: "inherit", fontSize: 12, outline: "none",
+                  }}
+                />
+                <textarea
+                  required
+                  minLength={20}
+                  value={reportStatement}
+                  onChange={(e) => setReportStatement(e.target.value)}
+                  placeholder="Where it appears and why you believe it infringes (required)"
+                  rows={4}
+                  style={{
+                    width: "100%", boxSizing: "border-box", marginBottom: 10, padding: "8px 10px",
+                    borderRadius: 8, border: "1px solid hsla(210, 30%, 80%, 0.14)", background: "hsla(220, 28%, 12%, 0.6)",
+                    color: "inherit", fontSize: 12, outline: "none", resize: "vertical",
+                  }}
+                />
+                <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                  <button
+                    type="submit"
+                    disabled={reportBusy || reportStatement.trim().length < 20}
+                    style={{
+                      padding: "8px 14px", borderRadius: 8, border: "1px solid hsl(213 45% 42%)",
+                      background: "hsl(213 55% 32%)", color: "#fff", fontSize: 12, fontWeight: 650,
+                      cursor: reportBusy ? "default" : "pointer", opacity: reportBusy ? 0.6 : 1,
+                    }}
+                  >
+                    {reportBusy ? "Sending…" : "Submit report"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setReportOpen(false)}
+                    disabled={reportBusy}
+                    style={{
+                      padding: "8px 12px", borderRadius: 8, border: "1px solid hsla(210, 30%, 80%, 0.14)",
+                      background: "transparent", color: "hsla(210, 14%, 70%, 0.85)", fontSize: 12, cursor: "pointer",
+                    }}
+                  >
+                    Close
+                  </button>
+                </div>
+                {reportStatus ? (
+                  <p style={{ margin: "10px 0 0", fontSize: 11, color: "hsla(213, 75%, 72%, 1)" }}>{reportStatus}</p>
+                ) : null}
+              </motion.form>
+            </motion.div>
           )}
         </AnimatePresence>
       </div>

--- a/src/components/GamesPage.tsx
+++ b/src/components/GamesPage.tsx
@@ -797,6 +797,9 @@ export default function GamesPage({ onNavigate, adminEdit = false, initialQuery 
               <div className="pt-4 pb-2">
                 <AdResponsiveBanner />
                 <AdNativeBar />
+                <p className="text-[10px] text-white/35 leading-relaxed mt-3 max-w-xl">
+                  Titles belong to their owners. Rights holders can report an issue from a game&apos;s controls or email our copyright address. We disable access after a valid notice.
+                </p>
               </div>
               {hasMore && (
                 <div ref={loadMoreRef} className="flex justify-center py-8">

--- a/src/components/LegalTermsPopup.tsx
+++ b/src/components/LegalTermsPopup.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { getSiteOrigin } from "@/lib/siteOrigin";
+
+export default function LegalTermsPopup() {
+  const origin = getSiteOrigin();
+  const href = (p: string) => (origin ? origin + p : p);
+  const [show, setShow] = useState(false);
+  const [version, setVersion] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState("");
+
+  useEffect(() => {
+    let gone = false;
+    fetch("/api/legal/status", { credentials: "include" })
+      .then((r) => r.json())
+      .then((d) => {
+        if (gone) return;
+        setVersion(d.version || "");
+        if (d.gate && !d.accepted) setShow(true);
+      })
+      .catch(() => {});
+    return () => {
+      gone = true;
+    };
+  }, []);
+
+  async function accept() {
+    if (busy) return;
+    setBusy(true);
+    setStatus("");
+    try {
+      const r = await fetch("/api/legal/accept", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json", Accept: "application/json" },
+        body: JSON.stringify({ accepted: true, version }),
+      });
+      const d = await r.json().catch(() => ({}));
+      if (!r.ok) {
+        setStatus(d.error || "Could not save. Please try again.");
+        setBusy(false);
+        return;
+      }
+      window.location.reload();
+    } catch {
+      setStatus("Network error. Please try again.");
+      setBusy(false);
+    }
+  }
+
+  return (
+    <AnimatePresence>
+      {show && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="fixed inset-0 z-[1000] flex items-center justify-center p-6"
+        >
+          <div
+            className="absolute inset-0"
+            style={{ background: "hsla(220, 40%, 4%, 0.72)", backdropFilter: "blur(10px)" }}
+          />
+          <motion.div
+            initial={{ opacity: 0, y: 14, scale: 0.98 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 8, scale: 0.99 }}
+            transition={{ duration: 0.28, ease: [0.25, 0.46, 0.45, 0.94] }}
+            className="relative z-10 w-full max-w-sm flex flex-col items-center text-center"
+          >
+            <div
+              className="w-14 h-14 rounded-2xl flex items-center justify-center mb-4"
+              style={{
+                background: "hsl(216 30% 10%)",
+                border: "1px solid hsl(213 40% 32%)",
+                color: "hsl(213 80% 80%)",
+              }}
+            >
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+              </svg>
+            </div>
+            <p className="text-[10px] font-bold uppercase tracking-[0.16em] mb-2" style={{ color: "hsl(213 75% 68%)" }}>
+              Updated policies
+            </p>
+            <h2 className="text-2xl font-extrabold tracking-tight mb-2" style={{ color: "hsl(0 0% 100%)" }}>
+              A quick update
+            </h2>
+            <p className="text-sm leading-relaxed mb-5 max-w-[32ch]" style={{ color: "hsl(216 15% 72%)" }}>
+              Our Terms, Privacy Policy, and Copyright Policy were revised. Please review and continue.
+            </p>
+            <p className="text-[11px] leading-relaxed mb-5 max-w-[34ch]" style={{ color: "hsl(216 15% 60%)" }}>
+              By continuing you agree to the{" "}
+              <a href={href("/terms")} target="_blank" rel="noopener noreferrer" style={{ color: "hsl(213 75% 68%)" }}>
+                Terms
+              </a>
+              ,{" "}
+              <a href={href("/privacy-policy")} target="_blank" rel="noopener noreferrer" style={{ color: "hsl(213 75% 68%)" }}>
+                Privacy Policy
+              </a>
+              , and{" "}
+              <a href={href("/dmca")} target="_blank" rel="noopener noreferrer" style={{ color: "hsl(213 75% 68%)" }}>
+                Copyright Policy
+              </a>
+              .
+            </p>
+            <button
+              type="button"
+              onClick={accept}
+              disabled={busy}
+              className="inline-flex items-center justify-center gap-2 px-6 py-3 rounded-xl text-sm font-semibold text-white w-full max-w-[280px]"
+              style={{
+                background: "hsl(213 55% 32%)",
+                border: "1px solid hsl(213 45% 42%)",
+                opacity: busy ? 0.6 : 1,
+                cursor: busy ? "default" : "pointer",
+              }}
+            >
+              I agree, continue
+            </button>
+            {status ? (
+              <p className="mt-3 text-[12px]" style={{ color: "hsl(0 70% 72%)" }}>
+                {status}
+              </p>
+            ) : (
+              <p className="mt-3 text-[11px]" style={{ color: "hsl(216 15% 52%)" }}>
+                Version {version}
+              </p>
+            )}
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/MoviesPage.tsx
+++ b/src/components/MoviesPage.tsx
@@ -1,14 +1,10 @@
 import { useState, useEffect, useRef, type ReactNode } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import {
-  Play, X, Film, Search, Heart, ArrowLeft, Tv, Star, Clapperboard, Sparkles,
-  ChevronLeft, ChevronRight, Info, Loader2,
+  Play, X, Film, Search, Heart, Tv, Star, Clapperboard, Sparkles, Info,
 } from "lucide-react";
-import { pxEncode, pxReady } from "@/lib/px";
-import { applyVpnRegion, isSignedIn } from "@/lib/vpn";
-import { setPendingAuth } from "@/lib/authPending";
 import { AdResponsiveBanner } from "@/components/ads/Adsterra";
-import { sealPlayerPopups, setPopupLock } from "@/lib/sealPlayerPopups";
+import MoviesWatchPanel from "@/components/MoviesWatchPanel";
 
 interface CatalogItem {
   id: number;
@@ -21,19 +17,6 @@ interface CatalogItem {
   first_air_date?: string;
   vote_average?: number;
   media_type?: string;
-}
-
-interface SeasonInfo {
-  season_number: number;
-  name?: string;
-  episode_count?: number;
-}
-
-interface EpisodeInfo {
-  episode_number: number;
-  name?: string;
-  overview?: string;
-  still_path?: string;
 }
 
 interface SavedMovie {
@@ -87,143 +70,6 @@ const S = {
 const TMDB_IMG = "https://image.tmdb.org/t/p/w342";
 const TMDB_BACKDROP = "https://image.tmdb.org/t/p/w1280";
 const TMDB_STILL = "https://image.tmdb.org/t/p/w300";
-
-const PROVIDERS = [
-  {
-    id: "vidnest",
-    label: "VidNest",
-    movie: (id: number) => `https://vidnest.fun/movie/${id}`,
-    tv: (id: number, s: number, e: number) => `https://vidnest.fun/tv/${id}/${s}/${e}`,
-  },
-  {
-    id: "vidking",
-    label: "VidKing",
-    movie: (id: number) => `https://www.vidking.net/embed/movie/${id}`,
-    tv: (id: number, s: number, e: number) => `https://www.vidking.net/embed/tv/${id}/${s}/${e}`,
-  },
-  {
-    id: "vidlink",
-    label: "VidLink",
-    movie: (id: number) => `https://vidlink.pro/movie/${id}`,
-    tv: (id: number, s: number, e: number) => `https://vidlink.pro/tv/${id}/${s}/${e}`,
-  },
-  {
-    id: "vidsrc",
-    label: "VidSrc",
-    movie: (id: number) => `https://vidsrc.xyz/embed/movie/${id}`,
-    tv: (id: number, s: number, e: number) => `https://vidsrc.xyz/embed/tv/${id}/${s}-${e}`,
-  },
-  {
-    id: "vidsrccc",
-    label: "VidSrc CC",
-    movie: (id: number) => `https://vidsrc.cc/v2/embed/movie/${id}`,
-    tv: (id: number, s: number, e: number) => `https://vidsrc.cc/v2/embed/tv/${id}/${s}/${e}`,
-  },
-  {
-    id: "vidsrcnet",
-    label: "VidSrc Net",
-    movie: (id: number) => `https://vidsrc.net/embed/movie/${id}`,
-    tv: (id: number, s: number, e: number) => `https://vidsrc.net/embed/tv/${id}/${s}-${e}`,
-  },
-  {
-    id: "embedsu",
-    label: "EmbedSU",
-    movie: (id: number) => `https://embed.su/embed/movie/${id}`,
-    tv: (id: number, s: number, e: number) => `https://embed.su/embed/tv/${id}/${s}/${e}`,
-  },
-  {
-    id: "multiembed",
-    label: "MultiEmbed",
-    movie: (id: number) => `https://multiembed.mov/?video_id=${id}&tmdb=1`,
-    tv: (id: number, s: number, e: number) => `https://multiembed.mov/?video_id=${id}&tmdb=1&s=${s}&e=${e}`,
-  },
-  {
-    id: "moviesapi",
-    label: "MoviesAPI",
-    movie: (id: number) => `https://moviesapi.club/movie/${id}`,
-    tv: (id: number, s: number, e: number) => `https://moviesapi.club/tv/${id}-${s}-${e}`,
-  },
-  {
-    id: "2embed",
-    label: "2Embed",
-    movie: (id: number) => `https://www.2embed.cc/embed/${id}`,
-    tv: (id: number, s: number, e: number) => `https://www.2embed.cc/embedtv/${id}&s=${s}&e=${e}`,
-  },
-  {
-    id: "autoembed",
-    label: "AutoEmbed",
-    movie: (id: number) => `https://player.autoembed.cc/embed/movie/${id}`,
-    tv: (id: number, s: number, e: number) => `https://player.autoembed.cc/embed/tv/${id}/${s}/${e}`,
-  },
-];
-
-const VIRGINIA_REGION = "4";
-const TOR_REGION = "tor";
-const BLACK_FAIL_MS = 20000;
-const AUTO_SOURCE_HOPS = [
-  { provider: "vidnest", region: VIRGINIA_REGION, label: "VidNest" },
-  { provider: "vidnest", region: TOR_REGION, label: "VidNest · Tor" },
-  { provider: "vidlink", region: TOR_REGION, label: "VidLink · Tor" },
-] as const;
-
-function collectVideos(root: Window | Document | ShadowRoot, depth = 0, out: HTMLVideoElement[] = []): HTMLVideoElement[] {
-  if (!root || depth > 5) return out;
-  try {
-    const scope: ParentNode | null = "document" in root && (root as Window).document
-      ? (root as Window).document
-      : (root as ParentNode);
-    if (!scope || typeof scope.querySelectorAll !== "function") return out;
-    scope.querySelectorAll("video").forEach((v) => out.push(v as HTMLVideoElement));
-    scope.querySelectorAll("*").forEach((el) => {
-      const sr = (el as HTMLElement).shadowRoot;
-      if (sr) collectVideos(sr, depth + 1, out);
-    });
-    if (depth < 4) {
-      scope.querySelectorAll("iframe").forEach((frame) => {
-        try {
-          const w = (frame as HTMLIFrameElement).contentWindow;
-          if (w) collectVideos(w, depth + 1, out);
-        } catch {}
-      });
-    }
-  } catch {}
-  return out;
-}
-
-function mediaLooksAlive(v: HTMLVideoElement, lastTimes: WeakMap<HTMLVideoElement, number>): boolean {
-  const t = Number(v.currentTime) || 0;
-  const prev = lastTimes.get(v);
-  lastTimes.set(v, t);
-  if (typeof prev === "number" && t > prev + 0.12) return true;
-  const hasFrame = (v.readyState || 0) >= 2 && v.videoWidth >= 16 && v.videoHeight >= 16;
-  if (hasFrame) return true;
-  if (!v.paused && t > 0.25) return true;
-  try {
-    if (v.played && v.played.length > 0 && v.played.end(v.played.length - 1) > 0.3) return true;
-  } catch {}
-  return false;
-}
-
-function inspectPlayerIframe(
-  iframe: HTMLIFrameElement | null,
-  lastTimes: WeakMap<HTMLVideoElement, number>
-): "alive" | "dead" | "unknown" {
-  if (!iframe) return "dead";
-  let win: Window | null = null;
-  let doc: Document | null = null;
-  try {
-    win = iframe.contentWindow;
-    doc = iframe.contentDocument || win?.document || null;
-  } catch {
-    return "unknown";
-  }
-  if (!win || !doc || !doc.body) return "unknown";
-  const videos = collectVideos(win);
-  for (const v of videos) {
-    if (mediaLooksAlive(v, lastTimes)) return "alive";
-  }
-  return "dead";
-}
 
 function getSavedMovies(): { items: SavedMovie[]; groups: MovieGroup[] } {
   try {
@@ -389,710 +235,24 @@ function ShelfRow({
 }
 
 function MoviePlayer({
-  state, onBack, onUpdate, recommended, onPlayRecommended,
+  state, onBack, onOpenService,
 }: {
   state: PlayerState;
   onBack: () => void;
-  onUpdate: (next: Partial<PlayerState>) => void;
-  recommended: CatalogItem[];
-  onPlayRecommended: (item: CatalogItem, type: "movie" | "tv") => void;
+  onOpenService: (url: string, label: string) => void;
 }) {
-  const frameHostRef = useRef<HTMLDivElement>(null);
-  const iframeRef = useRef<HTMLIFrameElement | null>(null);
-  const [watching, setWatching] = useState(false);
-  const [provider, setProvider] = useState("vidnest");
-  const [season, setSeason] = useState(state.season || 1);
-  const [episode, setEpisode] = useState(state.episode || 1);
-  const [seasons, setSeasons] = useState<SeasonInfo[]>([]);
-  const [episodes, setEpisodes] = useState<EpisodeInfo[]>([]);
-  const [frameReady, setFrameReady] = useState(false);
-  const [loadError, setLoadError] = useState("");
-  const [barVisible, setBarVisible] = useState(true);
-  const [hopIndex, setHopIndex] = useState(0);
-  const [sourceNote, setSourceNote] = useState("");
-  const hideBarTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const autoHopRef = useRef(true);
-  const hopIndexRef = useRef(0);
-  const providerRef = useRef(provider);
-  providerRef.current = provider;
-
-  useEffect(() => {
-    const prev = localStorage.getItem("selectedVpnRegion") || "default";
-    if (prev !== VIRGINIA_REGION && prev !== TOR_REGION) {
-      localStorage.setItem("pz-vpn-before-movies", prev);
-    }
-    applyVpnRegion(VIRGINIA_REGION);
-    return () => {
-      const restore = localStorage.getItem("pz-vpn-before-movies") || "default";
-      applyVpnRegion(restore);
-    };
-  }, []);
-
-  useEffect(() => {
-    setSeason(state.season || 1);
-    setEpisode(state.episode || 1);
-    setWatching(false);
-    setFrameReady(false);
-    autoHopRef.current = true;
-    hopIndexRef.current = 0;
-    setHopIndex(0);
-    setProvider("vidnest");
-    setSourceNote("");
-  }, [state.tmdbId, state.type]);
-
-  useEffect(() => {
-    if (state.type !== "tv") {
-      setSeasons([]);
-      setEpisodes([]);
-      return;
-    }
-    fetch(`/api/tmdb/tv/${state.tmdbId}`)
-      .then((r) => r.json())
-      .then((d) => {
-        const list: SeasonInfo[] = (d.seasons || []).filter((s: SeasonInfo) => s.season_number > 0);
-        setSeasons(list);
-      })
-      .catch(() => setSeasons([]));
-  }, [state.tmdbId, state.type]);
-
-  useEffect(() => {
-    if (state.type !== "tv") return;
-    fetch(`/api/tmdb/tv/${state.tmdbId}/season/${season}`)
-      .then((r) => r.json())
-      .then((d) => setEpisodes(d.episodes || []))
-      .catch(() => setEpisodes([]));
-  }, [state.tmdbId, state.type, season]);
-
-  useEffect(() => {
-    onUpdate({ season, episode });
-  }, [season, episode]);
-
-  useEffect(() => {
-    setPopupLock(true);
-    const prevOpen = window.open;
-    window.open = function () {
-      return null;
-    } as typeof window.open;
-    const blockAux = (e: MouseEvent) => {
-      if (e.button === 1) {
-        e.preventDefault();
-        e.stopPropagation();
-      }
-    };
-    const blockBlank = (e: MouseEvent) => {
-      const a = (e.target as Element | null)?.closest?.("a");
-      if (!a) return;
-      const t = (a.getAttribute("target") || "").toLowerCase();
-      if (t === "_blank" || t === "_new") {
-        e.preventDefault();
-        e.stopPropagation();
-      }
-    };
-    document.addEventListener("auxclick", blockAux, true);
-    document.addEventListener("click", blockBlank, true);
-    return () => {
-      setPopupLock(false);
-      window.open = prevOpen;
-      document.removeEventListener("auxclick", blockAux, true);
-      document.removeEventListener("click", blockBlank, true);
-    };
-  }, []);
-
-  useEffect(() => {
-    if (!watching) {
-      try {
-        if (iframeRef.current?.parentNode) iframeRef.current.parentNode.removeChild(iframeRef.current);
-      } catch {}
-      iframeRef.current = null;
-      setFrameReady(false);
-      return;
-    }
-
-    const host = frameHostRef.current;
-    if (!host) return;
-    let cancelled = false;
-    let timer: ReturnType<typeof setInterval> | null = null;
-    let sealTimer: ReturnType<typeof setInterval> | null = null;
-
-    const cleanup = () => {
-      try {
-        if (iframeRef.current?.parentNode) iframeRef.current.parentNode.removeChild(iframeRef.current);
-      } catch {}
-      iframeRef.current = null;
-    };
-
-    const sealFrame = (iframe: HTMLIFrameElement) => {
-      sealPlayerPopups(iframe);
-    };
-
-    const hop = AUTO_SOURCE_HOPS[hopIndex] || AUTO_SOURCE_HOPS[0];
-    const providerId = autoHopRef.current ? hop.provider : provider;
-    const regionId = autoHopRef.current
-      ? hop.region
-      : (localStorage.getItem("selectedVpnRegion") || VIRGINIA_REGION);
-    const prov = PROVIDERS.find((p) => p.id === providerId) || PROVIDERS[0];
-
-    const mount = () => {
-      if (!pxReady()) return false;
-      try {
-        cleanup();
-        const target =
-          state.type === "tv"
-            ? prov.tv(state.tmdbId, season, episode)
-            : prov.movie(state.tmdbId);
-
-        const iframe = document.createElement("iframe");
-        iframe.style.cssText =
-          "position:absolute;inset:0;width:100%;height:100%;border:none;background:#000;opacity:0;transition:opacity 0.25s ease;";
-        iframe.allow = "autoplay; fullscreen; encrypted-media; picture-in-picture";
-        iframe.allowFullscreen = true;
-        iframe.referrerPolicy = "no-referrer";
-        iframe.setAttribute(
-          "sandbox",
-          "allow-scripts allow-same-origin allow-forms allow-presentation"
-        );
-        iframe.title = "Player";
-        iframe.onload = () => {
-          iframe.dataset.pzReady = "1";
-          iframe.style.opacity = "1";
-          sealFrame(iframe);
-        };
-        iframe.src = pxEncode(target);
-        host.appendChild(iframe);
-        iframeRef.current = iframe;
-        setFrameReady(true);
-        setLoadError("");
-        return true;
-      } catch (e: any) {
-        setLoadError(e?.message || "Failed to start player");
-        return false;
-      }
-    };
-
-    setFrameReady(false);
-    (async () => {
-      await applyVpnRegion(regionId);
-      if (cancelled) return;
-      if (!mount()) {
-        timer = setInterval(() => {
-          if (cancelled) return;
-          if (mount() && timer) clearInterval(timer);
-        }, 120);
-      }
-    })();
-
-    sealTimer = setInterval(() => {
-      if (iframeRef.current) sealFrame(iframeRef.current);
-    }, 250);
-
-    return () => {
-      cancelled = true;
-      if (timer) clearInterval(timer);
-      if (sealTimer) clearInterval(sealTimer);
-      cleanup();
-    };
-  }, [watching, provider, hopIndex, state.tmdbId, state.type, season, episode]);
-
-  useEffect(() => {
-    if (!watching || !autoHopRef.current) return;
-    const lastTimes = new WeakMap<HTMLVideoElement, number>();
-    let deadMs = 0;
-    let aliveHits = 0;
-    let locked = false;
-    const tickMs = 1000;
-    const timer = window.setInterval(() => {
-      if (!autoHopRef.current || locked) return;
-      const iframe = iframeRef.current;
-      if (!iframe || iframe.dataset.pzReady !== "1") {
-        deadMs += tickMs;
-      } else {
-        const verdict = inspectPlayerIframe(iframe, lastTimes);
-        if (verdict === "alive") {
-          aliveHits += 1;
-          deadMs = 0;
-          if (aliveHits >= 2) locked = true;
-          setSourceNote("");
-          return;
-        }
-        if (verdict === "unknown") return;
-        deadMs += tickMs;
-      }
-      if (deadMs < BLACK_FAIL_MS) return;
-      deadMs = 0;
-      const next = hopIndexRef.current + 1;
-      if (next >= AUTO_SOURCE_HOPS.length) {
-        autoHopRef.current = false;
-        setSourceNote("Still not playing — try another source");
-        return;
-      }
-      hopIndexRef.current = next;
-      setHopIndex(next);
-      setProvider(AUTO_SOURCE_HOPS[next].provider);
-      setSourceNote("Switching source…");
-    }, tickMs);
-    return () => window.clearInterval(timer);
-  }, [watching, hopIndex, provider, state.tmdbId, state.type, season, episode]);
-
-  const bumpBar = () => {
-    setBarVisible(true);
-    if (hideBarTimer.current) clearTimeout(hideBarTimer.current);
-    hideBarTimer.current = setTimeout(() => setBarVisible(false), 2800);
-  };
-
-  useEffect(() => {
-    if (!watching) return;
-    bumpBar();
-    return () => {
-      if (hideBarTimer.current) clearTimeout(hideBarTimer.current);
-    };
-  }, [watching, episode, season]);
-
-  const pickProvider = (id: string) => {
-    autoHopRef.current = false;
-    setSourceNote("");
-    setProvider(id);
-  };
-
-  const startWatch = (ep?: number) => {
-    if (typeof ep === "number") setEpisode(ep);
-    if (provider === "vidnest" || provider === "vidlink" || !PROVIDERS.some((p) => p.id === provider)) {
-      autoHopRef.current = true;
-      const hop = provider === "vidlink" ? 2 : 0;
-      hopIndexRef.current = hop;
-      setHopIndex(hop);
-      setProvider(AUTO_SOURCE_HOPS[hop].provider);
-      setSourceNote("");
-    } else {
-      autoHopRef.current = false;
-    }
-    setWatching(true);
-  };
-
-  const episodeList = episodes.length
-    ? episodes
-    : Array.from({ length: Math.max(episode, 12) }, (_, i) => ({
-        episode_number: i + 1,
-        name: `Episode ${i + 1}`,
-      }));
-
-  if (watching) {
-    return (
-      <div
-        style={{ position: "absolute", inset: 0, background: "#000", display: "flex", flexDirection: "column" }}
-        onMouseMove={bumpBar}
-        onClick={bumpBar}
-      >
-        <div style={{ flex: 1, position: "relative", minHeight: 0 }}>
-          <div ref={frameHostRef} style={{ position: "absolute", inset: 0 }} />
-          {!frameReady && (
-            <div style={{
-              position: "absolute", inset: 0, display: "flex", alignItems: "center",
-              justifyContent: "center", color: S.textMuted, fontSize: 12, zIndex: 2,
-            }}>
-              {loadError || "Loading player…"}
-            </div>
-          )}
-          {sourceNote ? (
-            <div style={{
-              position: "absolute", inset: 0, zIndex: 6, display: "flex",
-              alignItems: "center", justifyContent: "center", pointerEvents: "none",
-              background: sourceNote.startsWith("Switching") ? "hsla(220, 30%, 4%, 0.55)" : "transparent",
-            }}>
-              <div style={{
-                display: "flex", alignItems: "center", gap: 10, padding: "10px 14px",
-                borderRadius: 999, background: "hsla(220, 28%, 10%, 0.88)",
-                border: `1px solid ${S.border}`, color: S.text, fontSize: 12, fontWeight: 650,
-                backdropFilter: "blur(12px)",
-              }}>
-                {sourceNote.startsWith("Switching") ? <Loader2 size={14} className="animate-spin" /> : null}
-                <span>
-                  {sourceNote}
-                  {autoHopRef.current && hopIndex > 0 && sourceNote.startsWith("Switching")
-                    ? ` ${AUTO_SOURCE_HOPS[hopIndex]?.label || ""}`
-                    : ""}
-                </span>
-              </div>
-            </div>
-          ) : null}
-        </div>
-
-        <div
-          style={{
-            position: "absolute",
-            left: 0,
-            right: 0,
-            bottom: 0,
-            zIndex: 8,
-            padding: "10px 12px 12px",
-            background: "linear-gradient(to top, hsla(220,35%,4%,0.88), transparent)",
-            opacity: barVisible ? 1 : 0,
-            transform: barVisible ? "translateY(0)" : "translateY(8px)",
-            transition: "opacity 0.25s ease, transform 0.25s ease",
-            pointerEvents: barVisible ? "auto" : "none",
-          }}
-        >
-          <div style={{
-            display: "flex", alignItems: "center", gap: 8,
-            background: "hsla(220, 28%, 10%, 0.72)",
-            border: `1px solid ${S.border}`,
-            borderRadius: 999,
-            padding: "6px 8px 6px 6px",
-            backdropFilter: "blur(16px)",
-            maxWidth: 920,
-            margin: "0 auto",
-          }}>
-            <button
-              type="button"
-              onClick={() => setWatching(false)}
-              title="Back to details"
-              style={{
-                width: 28, height: 28, borderRadius: 999, border: `1px solid ${S.border}`,
-                background: "hsla(220,24%,16%,0.5)", color: S.textSub, cursor: "pointer",
-                display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0,
-              }}
-            >
-              <ArrowLeft size={12} />
-            </button>
-            <div style={{ minWidth: 0, flex: "0 1 140px" }}>
-              <p style={{ fontSize: 10, fontWeight: 700, color: S.text, margin: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                {state.title}
-              </p>
-              {state.type === "tv" && (
-                <p style={{ fontSize: 9, color: S.textMuted, margin: 0 }}>S{season} · E{episode}</p>
-              )}
-            </div>
-
-            {state.type === "tv" ? (
-              <>
-                <button
-                  type="button"
-                  onClick={() => setEpisode((e) => Math.max(1, e - 1))}
-                  style={{
-                    width: 26, height: 26, borderRadius: 999, border: `1px solid ${S.border}`,
-                    background: "transparent", color: S.textSub, cursor: "pointer",
-                    display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0,
-                  }}
-                >
-                  <ChevronLeft size={12} />
-                </button>
-                <div style={{ flex: 1, display: "flex", gap: 4, overflowX: "auto", scrollbarWidth: "none", minWidth: 0 }}>
-                  {episodeList.map((ep) => {
-                    const active = ep.episode_number === episode;
-                    return (
-                      <button
-                        key={ep.episode_number}
-                        type="button"
-                        onClick={() => setEpisode(ep.episode_number)}
-                        style={{
-                          flex: "0 0 auto",
-                          padding: "4px 8px",
-                          borderRadius: 999,
-                          fontSize: 10,
-                          fontWeight: 650,
-                          cursor: "pointer",
-                          border: `1px solid ${active ? S.borderFocus : "transparent"}`,
-                          background: active ? S.accentDim : "transparent",
-                          color: active ? S.text : S.textMuted,
-                        }}
-                      >
-                        E{ep.episode_number}
-                      </button>
-                    );
-                  })}
-                </div>
-                <button
-                  type="button"
-                  onClick={() => {
-                    const max = episodeList.length || episode + 1;
-                    setEpisode((e) => Math.min(max, e + 1));
-                  }}
-                  style={{
-                    width: 26, height: 26, borderRadius: 999, border: `1px solid ${S.border}`,
-                    background: "transparent", color: S.textSub, cursor: "pointer",
-                    display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0,
-                  }}
-                >
-                  <ChevronRight size={12} />
-                </button>
-              </>
-            ) : (
-              <div style={{ flex: 1 }} />
-            )}
-
-            <select
-              value={provider}
-              onChange={(e) => pickProvider(e.target.value)}
-              style={{
-                background: "transparent", border: `1px solid ${S.border}`, borderRadius: 999,
-                color: S.textSub, fontSize: 10, padding: "4px 8px", outline: "none", cursor: "pointer",
-                flexShrink: 0, maxWidth: 110,
-              }}
-            >
-              {PROVIDERS.map((p) => (
-                <option key={p.id} value={p.id}>{p.label}</option>
-              ))}
-            </select>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div style={{ position: "absolute", inset: 0, overflow: "hidden", background: "hsla(220, 35%, 4%, 0.96)" }}>
-      {state.backdrop_path && (
-        <div style={{ position: "absolute", inset: 0, zIndex: 0, pointerEvents: "none" }}>
-          <img
-            src={TMDB_BACKDROP + state.backdrop_path}
-            alt=""
-            style={{ width: "100%", height: "100%", objectFit: "cover", filter: "blur(2px) saturate(1.05)", opacity: 0.45 }}
-          />
-          <div style={{
-            position: "absolute", inset: 0,
-            background:
-              "linear-gradient(to right, hsla(220,35%,4%,0.92) 0%, hsla(220,35%,4%,0.72) 42%, hsla(220,35%,4%,0.55) 100%), linear-gradient(to top, hsla(220,35%,4%,0.96) 0%, hsla(220,35%,4%,0.35) 55%, hsla(220,35%,4%,0.55) 100%)",
-          }} />
-        </div>
-      )}
-
-      <div style={{ position: "relative", zIndex: 2, height: "100%", display: "flex", flexDirection: "column", minHeight: 0 }}>
-        <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "12px 18px", flexShrink: 0 }}>
-          <button
-            type="button"
-            onClick={onBack}
-            style={{
-              display: "flex", alignItems: "center", gap: 6, padding: "6px 11px",
-              background: "hsla(220, 28%, 12%, 0.55)", border: `1px solid ${S.border}`, borderRadius: 999,
-              color: S.textSub, fontSize: 11, cursor: "pointer", backdropFilter: "blur(12px)",
-            }}
-          >
-            <ArrowLeft size={12} /> Catalog
-          </button>
-          <div style={{ flex: 1 }} />
-          <select
-            value={provider}
-            onChange={(e) => pickProvider(e.target.value)}
-            style={{
-              background: "hsla(220, 28%, 12%, 0.55)", border: `1px solid ${S.border}`, borderRadius: 999,
-              color: S.textSub, fontSize: 10, padding: "6px 10px", outline: "none", cursor: "pointer",
-              backdropFilter: "blur(12px)",
-            }}
-          >
-            {PROVIDERS.map((p) => (
-              <option key={p.id} value={p.id}>{p.label}</option>
-            ))}
-          </select>
-        </div>
-
-        <div style={{
-          flex: 1, minHeight: 0, overflowY: "auto", padding: "4px 20px 20px",
-          display: "flex", flexDirection: "column", gap: 16, scrollbarWidth: "none",
-        }}>
-          <div style={{
-            display: "grid",
-            gridTemplateColumns: "minmax(0, 1.15fr) minmax(240px, 0.85fr)",
-            gap: 18,
-            alignItems: "start",
-          }}
-            className="pz-movie-detail-grid"
-          >
-            <div>
-              <div style={{ display: "flex", gap: 16, alignItems: "flex-start" }}>
-                {state.poster_path && (
-                  <img
-                    src={TMDB_IMG + state.poster_path}
-                    alt=""
-                    style={{
-                      width: 120, height: 180, objectFit: "cover", borderRadius: 14,
-                      border: `1px solid ${S.border}`, boxShadow: "0 16px 36px rgba(0,0,0,0.4)", flexShrink: 0,
-                    }}
-                  />
-                )}
-                <div style={{ minWidth: 0, flex: 1 }}>
-                  <p style={{
-                    fontSize: 10, fontWeight: 700, letterSpacing: "0.1em", textTransform: "uppercase",
-                    color: S.accent, margin: "0 0 6px",
-                  }}>
-                    {state.type === "tv" ? "Series" : "Movie"}
-                  </p>
-                  <h1 style={{
-                    fontSize: "clamp(1.35rem, 3vw, 2rem)", fontWeight: 800, color: S.text, margin: "0 0 8px",
-                    letterSpacing: "-0.03em", lineHeight: 1.1,
-                  }}>
-                    {state.title}
-                  </h1>
-                  {state.type === "tv" && (
-                    <p style={{ fontSize: 12, color: S.textSub, margin: "0 0 10px" }}>
-                      Season {season} · Episode {episode}
-                    </p>
-                  )}
-                  <p style={{
-                    fontSize: 13, color: S.textSub, margin: "0 0 16px", lineHeight: 1.5,
-                    display: "-webkit-box", WebkitLineClamp: 5, WebkitBoxOrient: "vertical", overflow: "hidden",
-                  }}>
-                    {state.overview || "Ready when you are."}
-                  </p>
-                  <button
-                    type="button"
-                    onClick={() => startWatch()}
-                    style={{
-                      display: "inline-flex", alignItems: "center", gap: 8, padding: "10px 16px",
-                      borderRadius: 999, border: "none", cursor: "pointer",
-                      background: "hsla(0,0%,98%,0.95)", color: "#0a0e16",
-                      fontSize: 12, fontWeight: 700,
-                      boxShadow: "0 10px 28px rgba(0,0,0,0.3)",
-                    }}
-                  >
-                    <Play size={13} fill="currentColor" />
-                    {state.type === "tv" ? `Watch E${episode}` : "Watch now"}
-                  </button>
-                </div>
-              </div>
-
-              {state.type === "tv" && (
-                <div style={{
-                  marginTop: 18, borderRadius: 16, border: `1px solid ${S.border}`,
-                  background: "hsla(220, 28%, 10%, 0.5)", backdropFilter: "blur(14px)",
-                  padding: "12px 12px 14px",
-                }}>
-                  <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 10, flexWrap: "wrap" }}>
-                    <p style={{ fontSize: 12, fontWeight: 700, color: S.text, margin: 0 }}>Episodes</p>
-                    <div style={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
-                      {(seasons.length ? seasons : [{ season_number: season }]).map((s) => (
-                        <button
-                          key={s.season_number}
-                          type="button"
-                          onClick={() => setSeason(s.season_number)}
-                          style={{
-                            padding: "4px 9px", borderRadius: 999, fontSize: 10, fontWeight: 650, cursor: "pointer",
-                            background: season === s.season_number ? S.accentDim : "transparent",
-                            border: `1px solid ${season === s.season_number ? S.borderFocus : S.border}`,
-                            color: season === s.season_number ? S.text : S.textSub,
-                          }}
-                        >
-                          S{s.season_number}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                  <div style={{
-                    display: "grid",
-                    gridTemplateColumns: "repeat(auto-fill, minmax(150px, 1fr))",
-                    gap: 8,
-                    maxHeight: 220,
-                    overflowY: "auto",
-                    scrollbarWidth: "thin",
-                  }}>
-                    {episodeList.map((ep) => {
-                      const active = ep.episode_number === episode;
-                      return (
-                        <button
-                          key={ep.episode_number}
-                          type="button"
-                          onClick={() => {
-                            setEpisode(ep.episode_number);
-                            startWatch(ep.episode_number);
-                          }}
-                          style={{
-                            display: "flex", gap: 8, alignItems: "center", textAlign: "left",
-                            padding: 6, borderRadius: 12, cursor: "pointer",
-                            background: active ? S.accentDim : "hsla(220,24%,16%,0.35)",
-                            border: `1px solid ${active ? S.borderFocus : S.border}`,
-                          }}
-                        >
-                          <div style={{
-                            width: 64, height: 36, borderRadius: 8, overflow: "hidden", flexShrink: 0,
-                            background: "hsla(220,28%,8%,0.8)", display: "flex", alignItems: "center", justifyContent: "center",
-                          }}>
-                            {ep.still_path ? (
-                              <img src={TMDB_STILL + ep.still_path} alt="" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
-                            ) : (
-                              <Play size={11} style={{ color: S.textMuted }} />
-                            )}
-                          </div>
-                          <div style={{ minWidth: 0 }}>
-                            <p style={{ fontSize: 10, fontWeight: 700, color: active ? S.accent : S.textMuted, margin: 0 }}>
-                              E{ep.episode_number}
-                            </p>
-                            <p style={{
-                              fontSize: 11, fontWeight: 550, color: S.text, margin: "1px 0 0",
-                              overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
-                            }}>
-                              {ep.name || `Episode ${ep.episode_number}`}
-                            </p>
-                          </div>
-                        </button>
-                      );
-                    })}
-                  </div>
-                </div>
-              )}
-            </div>
-
-            <div style={{
-              borderRadius: 16, border: `1px solid ${S.border}`,
-              background: "hsla(220, 28%, 10%, 0.5)", backdropFilter: "blur(14px)",
-              padding: "12px",
-              maxHeight: "min(70vh, 560px)",
-              overflow: "hidden",
-              display: "flex",
-              flexDirection: "column",
-            }}>
-              <p style={{ fontSize: 12, fontWeight: 700, color: S.text, margin: "0 0 10px" }}>
-                More like this
-              </p>
-              <div style={{
-                flex: 1, overflowY: "auto", display: "flex", flexDirection: "column", gap: 7,
-                scrollbarWidth: "thin",
-              }}>
-                {recommended.slice(0, 16).map((item) => {
-                  const type = mediaTypeOf(item);
-                  const title = item.title || item.name || "Untitled";
-                  const poster = item.poster_path ? TMDB_IMG + item.poster_path : "";
-                  return (
-                    <button
-                      key={`${type}-${item.id}`}
-                      type="button"
-                      onClick={() => onPlayRecommended(item, type)}
-                      style={{
-                        display: "flex", gap: 10, alignItems: "center", padding: 5, borderRadius: 12,
-                        background: "transparent", border: `1px solid ${S.border}`, cursor: "pointer", textAlign: "left",
-                      }}
-                    >
-                      <div style={{
-                        width: 42, height: 60, borderRadius: 8, overflow: "hidden",
-                        background: S.elevated, flexShrink: 0,
-                      }}>
-                        {poster && <img src={poster} alt="" style={{ width: "100%", height: "100%", objectFit: "cover" }} />}
-                      </div>
-                      <div style={{ minWidth: 0 }}>
-                        <p style={{
-                          fontSize: 12, fontWeight: 650, color: S.text, margin: 0,
-                          overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
-                        }}>
-                          {title}
-                        </p>
-                        <p style={{ fontSize: 10, color: S.textMuted, margin: "3px 0 0" }}>
-                          {type === "tv" ? "Series" : "Movie"}
-                        </p>
-                      </div>
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <style>{`
-        @media (max-width: 820px) {
-          .pz-movie-detail-grid {
-            grid-template-columns: 1fr !important;
-          }
-        }
-      `}</style>
-    </div>
+    <MoviesWatchPanel
+      type={state.type}
+      tmdbId={state.tmdbId}
+      title={state.title}
+      overview={state.overview}
+      poster={state.poster_path}
+      backdrop={state.backdrop_path}
+      rating={undefined}
+      onBack={onBack}
+      onOpenService={onOpenService}
+    />
   );
 }
 
@@ -1145,13 +305,7 @@ export default function MoviesPage({
     }
   };
 
-  const openPlayer = async (item: CatalogItem, type: "movie" | "tv") => {
-    const ok = await isSignedIn();
-    if (!ok) {
-      setPendingAuth({ type: "movies" });
-      onNavigate?.("petezah://account");
-      return;
-    }
+  const openPlayer = (item: CatalogItem, type: "movie" | "tv") => {
     const saved = items.find((i) => i.tmdbId === item.id && i.type === type);
     setPlayerState({
       type,
@@ -1163,6 +317,11 @@ export default function MoviesPage({
       season: type === "tv" ? saved?.season || 1 : undefined,
       episode: type === "tv" ? saved?.episode || 1 : undefined,
     });
+  };
+
+  const openService = (url: string, label: string) => {
+    if (!onNavigate || !url) return;
+    onNavigate(`petezah://appviewer?url=${encodeURIComponent(url)}&title=${encodeURIComponent(label)}`);
   };
 
   useEffect(() => { saveFavorites(data); }, [data]);
@@ -1214,31 +373,14 @@ export default function MoviesPage({
 
   const continueList = items.slice(0, 12);
   const featured = (!searchQuery && (trending[0] || catalog[0])) || null;
-  const recommended = (trending.length ? trending : catalog).filter(
-    (i) => !playerState || i.id !== playerState.tmdbId
-  );
 
   if (playerState) {
     return (
       <MoviePlayer
         key={`${playerState.type}-${playerState.tmdbId}`}
         state={playerState}
-        onBack={() => {
-          if (playerState.type === "tv") {
-            setData((prev) => ({
-              ...prev,
-              items: prev.items.map((i) =>
-                i.tmdbId === playerState.tmdbId && i.type === "tv"
-                  ? { ...i, season: playerState.season, episode: playerState.episode }
-                  : i
-              ),
-            }));
-          }
-          setPlayerState(null);
-        }}
-        onUpdate={(next) => setPlayerState((prev) => (prev ? { ...prev, ...next } : null))}
-        recommended={recommended}
-        onPlayRecommended={openPlayer}
+        onBack={() => setPlayerState(null)}
+        onOpenService={openService}
       />
     );
   }
@@ -1291,7 +433,7 @@ export default function MoviesPage({
                 fontSize: 13, color: S.textSub, margin: "0 0 16px", lineHeight: 1.45,
                 display: "-webkit-box", WebkitLineClamp: 3, WebkitBoxOrient: "vertical", overflow: "hidden",
               }}>
-                {featured.overview || "Start watching now."}
+                {featured.overview || "See where you can watch this on a licensed service."}
               </p>
               <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
                 <button
@@ -1316,7 +458,7 @@ export default function MoviesPage({
                     color: S.text, fontSize: 12, fontWeight: 650, backdropFilter: "blur(10px)",
                   }}
                 >
-                  <Info size={13} /> See more
+                  <Info size={13} /> Where to watch
                 </button>
               </div>
             </div>
@@ -1373,7 +515,7 @@ export default function MoviesPage({
             <>
               {continueList.length > 0 && (
                 <div style={{ marginBottom: 28 }}>
-                  <SectionLabel><Play size={14} /> Continue Watching</SectionLabel>
+                  <SectionLabel><Play size={14} /> Saved</SectionLabel>
                   <div style={{ display: "flex", gap: 12, overflowX: "auto", paddingBottom: 8, scrollbarWidth: "none" }}>
                     {continueList.map((item) => (
                       <PosterCard

--- a/src/components/MoviesWatchPanel.tsx
+++ b/src/components/MoviesWatchPanel.tsx
@@ -1,0 +1,271 @@
+import { useEffect, useMemo, useState } from "react";
+import { ArrowLeft, ExternalLink, Loader2, Star } from "lucide-react";
+
+type Kind = "movie" | "tv";
+
+type Offer = {
+  id: number;
+  name: string;
+  logo: string | null;
+  url: string;
+  group: "subscription" | "free" | "rent" | "buy";
+};
+
+const S = {
+  text: "hsla(210, 20%, 96%, 0.95)",
+  textSub: "hsla(210, 14%, 70%, 0.78)",
+  textMuted: "hsla(210, 12%, 55%, 0.55)",
+  border: "hsla(210, 30%, 80%, 0.12)",
+  surface: "hsla(220, 28%, 12%, 0.38)",
+  accent: "hsla(205, 70%, 62%, 0.95)",
+  accentDim: "hsla(210, 40%, 55%, 0.16)",
+  gold: "hsl(42 90% 55%)",
+};
+
+const TMDB_BACKDROP = "https://image.tmdb.org/t/p/w1280";
+const TMDB_LOGO = "https://image.tmdb.org/t/p/w92";
+const REGION_KEY = "pz-watch-region";
+const REGIONS = ["US", "GB", "CA", "AU", "DE", "FR", "BR", "JP", "IN", "MX"];
+
+function readRegion() {
+  try {
+    const v = (localStorage.getItem(REGION_KEY) || "US").toUpperCase();
+    return REGIONS.includes(v) ? v : "US";
+  } catch {
+    return "US";
+  }
+}
+
+export default function MoviesWatchPanel({
+  type,
+  tmdbId,
+  title,
+  overview,
+  poster,
+  backdrop,
+  rating,
+  onBack,
+  onOpenService,
+}: {
+  type: Kind;
+  tmdbId: number;
+  title: string;
+  overview?: string;
+  poster?: string;
+  backdrop?: string;
+  rating?: number;
+  onBack: () => void;
+  onOpenService: (url: string, label: string) => void;
+}) {
+  const [region, setRegion] = useState(readRegion);
+  const [loading, setLoading] = useState(true);
+  const [offers, setOffers] = useState<Offer[]>([]);
+  const [justWatch, setJustWatch] = useState("");
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let gone = false;
+    setLoading(true);
+    setError("");
+    fetch(`/api/tmdb/${type}/${tmdbId}/watch?region=${encodeURIComponent(region)}`)
+      .then(async (r) => {
+        const d = await r.json().catch(() => ({}));
+        if (!r.ok) throw new Error(d.error || "Could not load services");
+        return d;
+      })
+      .then((d) => {
+        if (gone) return;
+        setOffers(Array.isArray(d.offers) ? d.offers : []);
+        setJustWatch(typeof d.link === "string" ? d.link : "");
+      })
+      .catch((e) => {
+        if (!gone) setError(e.message || "Could not load services");
+      })
+      .finally(() => {
+        if (!gone) setLoading(false);
+      });
+    return () => {
+      gone = true;
+    };
+  }, [type, tmdbId, region]);
+
+  const groups = useMemo(() => {
+    const order: Offer["group"][] = ["subscription", "free", "rent", "buy"];
+    return order
+      .map((g) => ({
+        id: g,
+        label:
+          g === "subscription"
+            ? "Included with a subscription"
+            : g === "free"
+              ? "Free with ads"
+              : g === "rent"
+                ? "Rent"
+                : "Buy",
+        items: offers.filter((o) => o.group === g),
+      }))
+      .filter((g) => g.items.length);
+  }, [offers]);
+
+  return (
+    <div style={{ position: "absolute", inset: 0, overflowY: "auto", scrollbarWidth: "none" }}>
+      <div style={{ position: "relative", minHeight: 220 }}>
+        {backdrop ? (
+          <img
+            src={TMDB_BACKDROP + backdrop}
+            alt=""
+            style={{ position: "absolute", inset: 0, width: "100%", height: "100%", objectFit: "cover" }}
+          />
+        ) : null}
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            background:
+              "linear-gradient(to top, hsla(220,35%,4%,0.96) 0%, hsla(220,35%,4%,0.72) 55%, hsla(220,35%,4%,0.4) 100%)",
+          }}
+        />
+        <div style={{ position: "relative", padding: "18px 22px 20px", maxWidth: 720 }}>
+          <button
+            type="button"
+            onClick={onBack}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 6,
+              marginBottom: 16,
+              padding: "6px 10px",
+              borderRadius: 999,
+              border: `1px solid ${S.border}`,
+              background: S.surface,
+              color: S.textSub,
+              cursor: "pointer",
+              fontSize: 11,
+              fontWeight: 650,
+            }}
+          >
+            <ArrowLeft size={12} /> Back
+          </button>
+          <p style={{ margin: "0 0 6px", fontSize: 10, fontWeight: 700, letterSpacing: "0.14em", textTransform: "uppercase", color: S.accent }}>
+            Watch with a licensed service
+          </p>
+          <h1 style={{ margin: "0 0 8px", fontSize: "clamp(1.4rem, 3.4vw, 2.1rem)", fontWeight: 800, color: S.text, letterSpacing: "-0.03em" }}>
+            {title}
+          </h1>
+          {typeof rating === "number" && rating > 0 ? (
+            <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 8 }}>
+              <Star size={12} fill={S.gold} color={S.gold} />
+              <span style={{ fontSize: 12, fontWeight: 700, color: S.gold }}>{rating.toFixed(1)}</span>
+            </div>
+          ) : null}
+          {overview ? (
+            <p style={{ margin: 0, fontSize: 13, lineHeight: 1.5, color: S.textSub, maxWidth: 560 }}>
+              {overview}
+            </p>
+          ) : null}
+        </div>
+      </div>
+
+      <div style={{ padding: "8px 22px 40px", maxWidth: 720 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 14, flexWrap: "wrap" }}>
+          <p style={{ margin: 0, fontSize: 12, color: S.textMuted }}>Availability in</p>
+          <select
+            value={region}
+            onChange={(e) => {
+              const v = e.target.value;
+              setRegion(v);
+              try {
+                localStorage.setItem(REGION_KEY, v);
+              } catch {}
+            }}
+            style={{
+              background: S.surface,
+              border: `1px solid ${S.border}`,
+              color: S.text,
+              borderRadius: 8,
+              padding: "6px 10px",
+              fontSize: 12,
+            }}
+          >
+            {REGIONS.map((r) => (
+              <option key={r} value={r}>
+                {r}
+              </option>
+            ))}
+          </select>
+        </div>
+        <p style={{ margin: "0 0 16px", fontSize: 12, lineHeight: 1.5, color: S.textSub }}>
+          PeteZah does not host movies or TV files. Choose a service you subscribe to. We open that
+          official site in this browser so you can sign in and watch under their terms.
+        </p>
+
+        {loading ? (
+          <div style={{ display: "flex", alignItems: "center", gap: 8, color: S.textMuted, fontSize: 12, padding: "20px 0" }}>
+            <Loader2 size={14} className="animate-spin" /> Looking up licensed services…
+          </div>
+        ) : error ? (
+          <p style={{ color: "hsl(0 60% 62%)", fontSize: 12 }}>{error}</p>
+        ) : !groups.length ? (
+          <p style={{ color: S.textMuted, fontSize: 12, lineHeight: 1.5 }}>
+            No listed services for this title in {region}. Try another region, or open the
+            availability directory.
+          </p>
+        ) : (
+          groups.map((g) => (
+            <div key={g.id} style={{ marginBottom: 18 }}>
+              <p style={{ margin: "0 0 8px", fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase", color: S.textMuted }}>
+                {g.label}
+              </p>
+              <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+                {g.items.map((o) => (
+                  <button
+                    key={`${g.id}-${o.id}`}
+                    type="button"
+                    onClick={() => onOpenService(o.url, o.name)}
+                    style={{
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: 8,
+                      padding: "8px 12px 8px 8px",
+                      borderRadius: 12,
+                      border: `1px solid ${S.border}`,
+                      background: S.surface,
+                      color: S.text,
+                      cursor: "pointer",
+                      fontSize: 12,
+                      fontWeight: 650,
+                    }}
+                  >
+                    {o.logo ? (
+                      <img src={TMDB_LOGO + o.logo} alt="" width={28} height={28} style={{ borderRadius: 6, objectFit: "cover" }} />
+                    ) : null}
+                    {o.name}
+                    <ExternalLink size={11} style={{ color: S.textMuted }} />
+                  </button>
+                ))}
+              </div>
+            </div>
+          ))
+        )}
+
+        {justWatch ? (
+          <button
+            type="button"
+            onClick={() => onOpenService(justWatch, "Where to Watch")}
+            style={{
+              marginTop: 8,
+              background: "none",
+              border: "none",
+              color: S.accent,
+              cursor: "pointer",
+              fontSize: 12,
+              fontWeight: 650,
+            }}
+          >
+            More availability details
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/MusicPage.tsx
+++ b/src/components/MusicPage.tsx
@@ -1032,6 +1032,9 @@ export default function MusicPage({
           >
             Music
           </motion.h1>
+          <p style={{ fontSize: 11, color: S.textMuted, margin: "0 4px 14px", lineHeight: 1.4, maxWidth: 220 }}>
+            Background listening while you use the rest of the site. Official embeds only.
+          </p>
 
           <SideBtn
             active={nav === "browse"}
@@ -1310,7 +1313,7 @@ export default function MusicPage({
             <div style={{ padding: "28px 22px 48px", minHeight: 140 }}>
               <AdResponsiveBanner exo={false} />
               <p style={{ margin: "10px 0 0", fontSize: 10, color: S.textMuted, lineHeight: 1.4 }}>
-                Playback via official YouTube and SoundCloud embeds. Metadata from iTunes Search. Content remains on those platforms.
+                This is an overlay so you can listen while using the rest of the Service — not a standalone music app or download library. Playback uses official YouTube and SoundCloud embeds. Metadata comes from iTunes Search. Audio stays on those platforms.
               </p>
             </div>
           </div>

--- a/src/components/SettingsPanels.tsx
+++ b/src/components/SettingsPanels.tsx
@@ -490,8 +490,8 @@ export function BehaviorSettings(props: Props) {
         <div style={{ borderBottom: `1px solid ${C.border}` }}>
           <ToggleRow
             C={C}
-            label="Autocloak"
-            desc="Open inside about:blank on load"
+            label="Blank window on load"
+            desc="Open in a blank window when the page loads"
             checked={s.autocloak === "true"}
             onChange={() => {
               const next = s.autocloak !== "true";
@@ -743,7 +743,7 @@ export function ProxySettings(props: Props) {
     <div style={{ maxWidth: 560 }}>
       <h2 style={{ fontSize: 16, fontWeight: 700, color: C.text, margin: "0 0 4px" }}>Proxy & browsing</h2>
       <p style={{ fontSize: 11, color: C.textSub, margin: "0 0 18px", lineHeight: 1.45 }}>
-        Tunnel endpoint, search, identity, and small quality-of-life switches for the browser shell.
+        Privacy tunnel for general web use. Follow the law and each site&apos;s terms. We do not condone illegal websites.
       </p>
 
       <p style={{ fontSize: 10, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: C.textMuted, margin: "0 0 8px" }}>

--- a/src/components/SvgAccessGate.tsx
+++ b/src/components/SvgAccessGate.tsx
@@ -340,9 +340,9 @@ export default function SvgAccessGate({ children }: { children: React.ReactNode 
             </a>
             , and{" "}
             <a href={href("/dmca")} target="_blank" rel="noopener noreferrer">
-              DMCA Policy
+              Copyright Policy
             </a>
-            .
+            . You must be 13 or older.
           </span>
         </label>
         <button type="button" className="continue" disabled={!canGo} onClick={continueOn}>

--- a/src/index.css
+++ b/src/index.css
@@ -487,6 +487,55 @@ body > #google_vignette {
     white-space: nowrap;
   }
 
+  /* account settings had a fixed 188px nav column that left almost no
+     room for the content panel on phones, see #22 */
+  .account-settings-shell {
+    flex-direction: column !important;
+  }
+  .account-settings-nav {
+    width: 100% !important;
+    flex-direction: row !important;
+    align-items: center !important;
+    flex-wrap: nowrap !important;
+    border-right: none !important;
+    border-bottom: 1px solid hsla(210, 40%, 80%, 0.08) !important;
+    padding: 8px !important;
+    gap: 8px;
+    overflow-x: auto !important;
+    overflow-y: hidden !important;
+    flex-shrink: 0 !important;
+    scrollbar-width: none;
+  }
+  .account-settings-nav::-webkit-scrollbar {
+    display: none;
+  }
+  .account-settings-nav-header {
+    flex-direction: row !important;
+    margin-bottom: 0 !important;
+    padding-bottom: 0 !important;
+    border-bottom: none !important;
+    flex-shrink: 0;
+  }
+  .account-settings-nav-header p {
+    display: none;
+  }
+  .account-settings-nav-list {
+    flex-direction: row !important;
+    overflow-x: visible !important;
+    overflow-y: visible !important;
+  }
+  .account-settings-nav-list button {
+    white-space: nowrap;
+  }
+  .account-settings-signout {
+    margin-top: 0 !important;
+    flex-shrink: 0;
+    white-space: nowrap;
+  }
+  .account-settings-content {
+    padding: 16px 14px !important;
+  }
+
   .newtab-presets {
     gap: 0.75rem !important;
     row-gap: 0.85rem !important;


### PR DESCRIPTION
found while doing a security pass on the login side.

`toIPv4()` (`backend/middleware/security.js`) and `getClientIP()` (`backend/utils/client-ip.js`) both read `x-forwarded-for` before (or, in `getClientIP`'s case, instead of) `cf-connecting-ip`. `x-forwarded-for` is whatever the client sent if the request reaches the origin at all outside cloudflare's edge, `cf-connecting-ip` isn't, cloudflare's edge sets that one and a client can't override it.

that matters here because both helpers feed every IP-keyed control in the app:
- `authLimiter` on `/api/signin` and `/api/signup` (20 attempts/15min per "ip")
- `isIpBanned()`, enforced site-wide via `createIpBanMiddleware`
- the circuit-breaker/reputation system in `security.js`
- `users.ip`, written straight from `getClientIP` with no format check

all of that was bypassable by sending a different `x-forwarded-for` value per request.

## change
prefer `cf-connecting-ip` first in both functions, fall back to the old `x-forwarded-for`/`x-real-ip`/socket chain if it's not present. if this app is ever reachable directly outside cloudflare (don't know the topology, said as much to the operator), that's a firewall-level gap this can't close on its own, worth confirming separately.

## verification
- `node --check` on both files
- exercised both functions directly with mock requests: cf header wins when present, spoofed xff alone still works exactly as before when there's no cf header (no regression for non-cloudflare setups), malformed cf value still falls back to loopback in `toIPv4`
- `npx eslint` clean on both files
- `npx vitest run` passes (no existing coverage for these functions, vitest is scoped to `src/**` only right now, backend has no test harness at all, separate issue not touched here)